### PR TITLE
bsd.port.mk: Use zstandard as default compression for FreeBSD 14+

### DIFF
--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -2226,11 +2226,11 @@ PKG_SUFX=	.pkg
 .    if defined(PKG_NOCOMPRESS)
 PKG_COMPRESSION_FORMAT?=	tar
 .    else
-#.if ${OSVERSION} > 1400000
-#PKG_COMPRESSION_FORMAT?=	tzst
-#.else
+.if ${OSVERSION} > 1400000
+PKG_COMPRESSION_FORMAT?=	tzst
+.else
 PKG_COMPRESSION_FORMAT?=	txz
-#.endif
+.endif
 .    endif
 
 # where pkg(8) stores its data


### PR DESCRIPTION
Cherry pick the upstream commit to switch to zstandard compression. This will require a full package rebuild, but should yield a better user experience (especially on qemu).