### PR TITLE
Allow to install port dependencies using package managers

### DIFF
--- a/Mk/Uses/cmake.mk
+++ b/Mk/Uses/cmake.mk
@@ -56,7 +56,7 @@ IGNORE=	Incorrect 'USES+= cmake:${cmake_ARGS}' usage: argument [${arg}] is not r
 .    endif
 .  endfor
 
-CMAKE_CMD_RUN=		${LOCALBASE}/bin/cmake
+CMAKE_CMD_RUN=		cmake
 .if defined(CMAKE_CMD)
 _CMAKE_PORT=		/nonexistent
 .else

--- a/Mk/Uses/python.mk
+++ b/Mk/Uses/python.mk
@@ -303,6 +303,14 @@ _PYTHON_FEATURE_${var:C/=.*$//:tu}=	${var:C/.*=//:S/,/ /g}
 IGNORE=		uses either USE_PYTHON=pytest or USE_PYTHON=pytest4, not both of them
 .  endif
 
+.  if defined(_PYTHON_FEATURE_DISTUTILS)
+# Currently, only hybrid ABI Python is available on CheriBSD.
+# A port dependency that is installed in the Python site-packages tree can be
+# installed with the hybrid ABI Python.
+BROKEN_purecap=	requires missing CheriABI Python
+USE_PKG64=	1
+.  endif
+
 # distutils automatically generates flavors depending on the supported
 # versions.
 .  if defined(_PYTHON_FEATURE_DISTUTILS)

--- a/Mk/Uses/python.mk
+++ b/Mk/Uses/python.mk
@@ -277,7 +277,7 @@ _INCLUDE_USES_PYTHON_MK=	yes
 # Mk/bsd.default-versions.mk in sync.
 _PYTHON_VERSIONS=		3.9 3.8 3.7 3.10 3.11 2.7 # preferred first
 _PYTHON_PORTBRANCH=		3.9		# ${_PYTHON_VERSIONS:[1]}
-_PYTHON_BASECMD=		${LOCALBASE}/bin/python
+_PYTHON_BASECMD=		python
 _PYTHON_RELPORTDIR=		lang/python
 
 # List all valid USE_PYTHON features here

--- a/Mk/bsd.commands.mk
+++ b/Mk/bsd.commands.mk
@@ -126,5 +126,7 @@ PKG_VERSION?=		${PKG_BIN} version
 PKG_CREATE?=		${PKG_BIN} create
 PKG_ADD?=		${PKG_BIN} add
 PKG_QUERY?=		${PKG_BIN} query
+PKG_INSTALL?=		${PKG_BIN} install
+PKG_RQUERY?=		${PKG_BIN} rquery
 
 .endif

--- a/Mk/bsd.commands.mk
+++ b/Mk/bsd.commands.mk
@@ -129,4 +129,10 @@ PKG_QUERY?=		${PKG_BIN} query
 PKG_INSTALL?=		${PKG_BIN} install
 PKG_RQUERY?=		${PKG_BIN} rquery
 
+PKG64_BIN?=		${LOCALBASE64}/sbin/pkg-static
+PKG64_INFO?=		${PKG64_BIN} info
+PKG64_INSTALL?=		${PKG64_BIN} install
+PKG64_QUERY?=		${PKG64_BIN} query
+PKG64_RQUERY?=		${PKG64_BIN} rquery
+
 .endif

--- a/Mk/bsd.options.mk
+++ b/Mk/bsd.options.mk
@@ -3,9 +3,13 @@
 # OPTIONS_DEFINE		- List of options this port accepts
 # OPTIONS_DEFINE_${ARCH}	- List of options this port accepts and are
 #				  specific to ${ARCH}
+# OPTIONS_DEFINE_${ABI}		- List of options this port accepts and are
+#				  specific to ${ABI}
 # OPTIONS_DEFAULT		- List of options activated by default
 # OPTIONS_DEFAULT_${ARCH}	- List of options activated by default for a
 #				  given arch
+# OPTIONS_DEFAULT_${ABI}	- List of options activated by default for a
+#				  given ABI
 #
 # ${OPTION}_DESC		- Description of the ${OPTION}
 #
@@ -33,6 +37,7 @@
 #
 # OPTIONS_EXCLUDE		- List of options unsupported (useful for slave ports)
 # OPTIONS_EXCLUDE_${ARCH}	- List of options unsupported on a given ${ARCH}
+# OPTIONS_EXCLUDE_${ABI}	- List of options unsupported for a given ${ABI}
 # OPTIONS_EXCLUDE_${OPSYS}	- List of options unsupported on a given ${OPSYS}
 # OPTIONS_EXCLUDE_${OPSYS}_${OSREL:R} - List of options unsupported on a given
 #				  ${OPSYS} and major version (11/12/13...)
@@ -211,18 +216,29 @@ _OPTIONS_TARGETS=	fetch:300:pre fetch:500:do fetch:700:post \
 			package:300:pre package:500:do package:700:post \
 			stage:800:post
 
-# Add per arch options
-.  for opt in ${OPTIONS_DEFINE_${ARCH}}
+# Add per architecture and ABI options
+_OPTIONS_DEFINE=	${OPTIONS_DEFINE_${ARCH}}
+.  for _abi in ${ABI}
+_OPTIONS_DEFINE+=	${OPTIONS_DEFINE_${_abi}}
+.  endfor
+.  for opt in ${_OPTIONS_DEFINE}
 .    if empty(OPTIONS_DEFINE:M${opt})
 OPTIONS_DEFINE+=	${opt}
 .    endif
 .  endfor
 
-# Add per arch defaults
+# Add per architecture and ABI defaults
 OPTIONS_DEFAULT+=	${OPTIONS_DEFAULT_${ARCH}}
+.  for _abi in ${ABI}
+OPTIONS_DEFAULT+=	${OPTIONS_DEFAULT_${_abi}}
+.  endfor
 
-_ALL_EXCLUDE=	${OPTIONS_EXCLUDE_${ARCH}} ${OPTIONS_EXCLUDE} \
-		${OPTIONS_SLAVE} ${OPTIONS_EXCLUDE_${OPSYS}} \
+_ALL_EXCLUDE=	${OPTIONS_EXCLUDE_${ARCH}}
+.  for _abi in ${ABI}
+_ALL_EXCLUDE+=	${OPTIONS_EXCLUDE_${_abi}}
+.  endfor
+_ALL_EXCLUDE+=	${OPTIONS_EXCLUDE} ${OPTIONS_SLAVE} \
+		${OPTIONS_EXCLUDE_${OPSYS}} \
 		${OPTIONS_EXCLUDE_${OPSYS}_${OSREL:R}}
 
 .  for opt in ${OPTIONS_DEFINE:O:u}

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -221,6 +221,10 @@ FreeBSD_MAINTAINER=	portmgr@FreeBSD.org
 #				  variables of the later stages using ${WRKDIR}/Makefile.inc
 #				  generated on the fly.
 #				  Default: not set.
+# USE_PKG64		- Set this if you want the port to be only installed with pkg64,
+#				  and not built from source, when it is required by a CheriABI
+#				  port and USE_PACKAGE_64_DEPENDS_ONLY is enabled.
+#				  Default: 0 (do not install the port with pkg64).
 #
 # NO_ARCH			- Set this if port is architecture neutral.
 #
@@ -413,6 +417,8 @@ FreeBSD_MAINTAINER=	portmgr@FreeBSD.org
 #
 # LOCALBASE		- Where ports install things.
 #				  Default: /usr/local
+# LOCALBASE64	  Where hybrid ABI programs are installed.
+#				  Default: /usr/local64
 # LINUXBASE		- Where Linux ports install things.
 #				  Default: /compat/linux
 # PREFIX		- Where *this* port installs its files.
@@ -986,6 +992,13 @@ FreeBSD_MAINTAINER=	portmgr@FreeBSD.org
 #				- When USE_PACKAGE_DEPENDS{,_ONLY} is enabled, try to use
 #				  a remote repository if a local package does not exist.
 #				  Default: 0 (no effect).
+# USE_PACKAGE_64_DEPENDS_ONLY
+#				- Install dependencies marked with USE_PKG64 using their
+#				  replacement hybrid ABI packages with pkg64 instead of building
+#				  them from scratch.
+#				  Do not fallback on source if a replacement package is not
+#				  present.
+#				  Default: 0 (no effect).
 # INSTALL_AS_USER
 #				- Define this to install as the current user, intended
 #				  for systems where you have no root access.
@@ -1018,6 +1031,7 @@ _LIST_OF_WITH_FEATURES=	debug lto ssp
 _DEFAULT_WITH_FEATURES=	ssp
 PORTSDIR?=		/usr/ports
 LOCALBASE?=		/usr/local
+LOCALBASE64?=	/usr/local64
 LINUXBASE?=		/compat/linux
 DISTDIR?=		${PORTSDIR}/distfiles
 _DISTDIR?=		${DISTDIR}/${DIST_SUBDIR}
@@ -1371,6 +1385,7 @@ PKGVERSION=	${PORTVERSION:C/[-_,]/./g}${_SUF1}${_SUF2}
 PKGNAME=	${PKGNAMEPREFIX}${PORTNAME}${PKGNAMESUFFIX}-${PKGVERSION}
 DISTVERSIONFULL=	${DISTVERSIONPREFIX}${DISTVERSION:C/:(.)/\1/g}${DISTVERSIONSUFFIX}
 DISTNAME?=	${PORTNAME}-${DISTVERSIONFULL}
+USE_PKG64?=	0
 
 INDEXFILE?=		INDEX-${OSVERSION:C/([0-9]*)[0-9]{5}/\1/}
 
@@ -4016,10 +4031,15 @@ ${deptype:tl}-depends:
 		dp_USE_PACKAGE_DEPENDS="${USE_PACKAGE_DEPENDS}" \
 		dp_USE_PACKAGE_DEPENDS_ONLY="${USE_PACKAGE_DEPENDS_ONLY}" \
 		dp_USE_PACKAGE_DEPENDS_REMOTE="${USE_PACKAGE_DEPENDS_REMOTE}" \
+		dp_USE_PACKAGE_64_DEPENDS_ONLY="${USE_PACKAGE_64_DEPENDS_ONLY}" \
 		dp_PKG_ADD="${PKG_ADD}" \
 		dp_PKG_INFO="${PKG_INFO}" \
 		dp_PKG_INSTALL="${PKG_INSTALL}" \
 		dp_PKG_RQUERY="${PKG_RQUERY}" \
+		dp_PKG64_INFO="${PKG64_INFO}" \
+		dp_PKG64_INSTALL="${PKG64_INSTALL}" \
+		dp_PKG64_QUERY="${PKG64_QUERY}" \
+		dp_PKG64_RQUERY="${PKG64_RQUERY}" \
 		dp_WRKDIR="${WRKDIR}" \
 		dp_PKGNAME="${PKGNAME}" \
 		dp_STRICT_DEPENDS="${STRICT_DEPENDS}" \

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -982,6 +982,10 @@ FreeBSD_MAINTAINER=	portmgr@FreeBSD.org
 #				  if an existing package is not present.
 # USE_PACKAGE_DEPENDS_ONLY
 #				- Like USE_PACKAGE_DEPENDS, but do not fallback on source.
+# USE_PACKAGE_DEPENDS_REMOTE
+#				- When USE_PACKAGE_DEPENDS{,_ONLY} is enabled, try to use
+#				  a remote repository if a local package does not exist.
+#				  Default: 0 (no effect).
 # INSTALL_AS_USER
 #				- Define this to install as the current user, intended
 #				  for systems where you have no root access.
@@ -4011,8 +4015,11 @@ ${deptype:tl}-depends:
 		dp_DEPENDS_ARGS="${DEPENDS_ARGS}" \
 		dp_USE_PACKAGE_DEPENDS="${USE_PACKAGE_DEPENDS}" \
 		dp_USE_PACKAGE_DEPENDS_ONLY="${USE_PACKAGE_DEPENDS_ONLY}" \
+		dp_USE_PACKAGE_DEPENDS_REMOTE="${USE_PACKAGE_DEPENDS_REMOTE}" \
 		dp_PKG_ADD="${PKG_ADD}" \
 		dp_PKG_INFO="${PKG_INFO}" \
+		dp_PKG_INSTALL="${PKG_INSTALL}" \
+		dp_PKG_RQUERY="${PKG_RQUERY}" \
 		dp_WRKDIR="${WRKDIR}" \
 		dp_PKGNAME="${PKGNAME}" \
 		dp_STRICT_DEPENDS="${STRICT_DEPENDS}" \

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -173,6 +173,8 @@ FreeBSD_MAINTAINER=	portmgr@FreeBSD.org
 # BROKEN_${ARCH} - Port is believed to be broken on ${ARCH}. Package builds
 #				  can still be attempted using TRYBROKEN to
 #				  test this assumption.
+# BROKEN_${ABI}  - Port is believed to be broken for ${ABI}.  Package builds can
+#				  still be attempted using TRYBROKEN to test this assumption.
 # BROKEN_${OPSYS} - Port is believed to be broken on ${OPSYS}. Package builds
 #				  can still be attempted using TRYBROKEN to
 #				  test this assumption.
@@ -1140,6 +1142,13 @@ PPC_ABI=	ELFv1
 .        endif
 .      endif
 _EXPORTED_VARS+=	PPC_ABI
+.    endif
+
+# Get the ABI
+.    if !defined(ABI)
+.      if (${ARCH:Maarch64*c*} || ${ARCH:Mriscv*c*})
+ABI+=	purecap
+.      endif
 .    endif
 
 # Get operating system versions for a cross build
@@ -2796,6 +2805,11 @@ IGNORE+= "${${f}_IGNORE_${OPSYS}_${v}}"
 .          endif
 .        endfor
 .      endfor
+.      for _abi in ${ABI}
+.        if defined(BROKEN_${_abi})
+_BROKEN_ABI=	yes
+.        endif
+.      endfor
 .      if (defined(IS_INTERACTIVE) && defined(BATCH))
 IGNORE=		is an interactive port
 .      elif (!defined(IS_INTERACTIVE) && defined(INTERACTIVE))
@@ -2822,6 +2836,14 @@ IGNORE=		is marked as broken: ${BROKEN}
 .        if !defined(TRYBROKEN)
 IGNORE=		is marked as broken on ${ARCH}: ${BROKEN_${ARCH}}
 .        endif
+.      elif defined(_BROKEN_ABI)
+.        for _abi in ${ABI}
+.          if defined(BROKEN_${_abi})
+.            if !defined(TRYBROKEN)
+IGNORE=		is marked as broken for ${_abi}: ${BROKEN_${_abi}}
+.            endif
+.          endif
+.        endfor
 .      elif defined(BROKEN_${OPSYS}_${OSREL:R}_${ARCH})
 .        if !defined(TRYBROKEN)
 IGNORE=		is marked as broken on ${OPSYS} ${OSREL} ${ARCH}: ${BROKEN_${OPSYS}_${OSREL:R}_${ARCH}}

--- a/devel/autoconf/Makefile
+++ b/devel/autoconf/Makefile
@@ -3,6 +3,9 @@ PORTVERSION=	2.71
 CATEGORIES=	devel
 MASTER_SITES=	GNU
 
+BROKEN_purecap=	requires missing CheriABI Python
+USE_PKG64=	1
+
 MAINTAINER=	tijl@FreeBSD.org
 COMMENT=	Generate configure scripts and related files
 

--- a/devel/automake/Makefile
+++ b/devel/automake/Makefile
@@ -3,6 +3,9 @@ PORTVERSION=	1.16.5
 CATEGORIES=	devel
 MASTER_SITES=	GNU
 
+BROKEN_purecap=	requires missing CheriABI Python
+USE_PKG64=	1
+
 MAINTAINER=	tijl@FreeBSD.org
 COMMENT=	GNU Standards-compliant Makefile generator
 

--- a/devel/cmake/Makefile
+++ b/devel/cmake/Makefile
@@ -5,6 +5,9 @@ CATEGORIES=	devel
 MASTER_SITES=	https://github.com/Kitware/CMake/releases/download/v${DISTVERSION}/ \
 		https://www.cmake.org/files/v${PORTVERSION}/
 
+BROKEN_purecap=	requires missing CheriABI Python
+USE_PKG64=	1
+
 MAINTAINER=	kde@FreeBSD.org
 COMMENT=	Cross-platform Makefile generator
 

--- a/devel/meson/Makefile
+++ b/devel/meson/Makefile
@@ -3,6 +3,9 @@ PORTVERSION=	0.62.2
 CATEGORIES=	devel python
 MASTER_SITES=	https://github.com/mesonbuild/${PORTNAME}/releases/download/${PORTVERSION}/
 
+BROKEN_purecap=	requires missing CheriABI Python
+USE_PKG64=	1
+
 MAINTAINER=	desktop@FreeBSD.org
 COMMENT=	High performance build system
 

--- a/devel/ninja/Makefile
+++ b/devel/ninja/Makefile
@@ -4,6 +4,9 @@ DISTVERSIONPREFIX=	v
 PORTEPOCH=	2
 CATEGORIES=	devel
 
+BROKEN_purecap=	requires missing CheriABI Python
+USE_PKG64=	1
+
 MAINTAINER=	kde@FreeBSD.org
 COMMENT=	Small build system closest in spirit to Make
 

--- a/lang/python39/Makefile
+++ b/lang/python39/Makefile
@@ -6,6 +6,9 @@ PKGNAMESUFFIX=	${PYTHON_SUFFIX}
 DISTNAME=	Python-${DISTVERSION}
 DIST_SUBDIR=	python
 
+BROKEN_purecap=	does not build for CheriABI
+USE_PKG64=	1
+
 MAINTAINER=	python@FreeBSD.org
 COMMENT=	Interpreted object-oriented programming language
 


### PR DESCRIPTION
This PR allows to install port dependencies from a remote package repository when the following variables are set:
```
USE_PACKAGE_DEPENDS=1
USE_PACKAGE_DEPENDS_REMOTE=1
```

It also allows to install port dependencies that aren't adapted to CheriABI yet, and are marked using `USE_PKG64=1` in their Makefiles, using pkg64 if the following variable is set:
```
USE_PACKAGE_64_DEPENDS_ONLY=1
```

At the moment, autoconf, automake, cmake, meson, ninja, python39 (the default Python) and all Python ports installed in the site-packages tree are marked as allowed to be installed with pkg64.