### PR TITLE
Disable Linux ports

### DIFF
--- a/Mk/Uses/linux.mk
+++ b/Mk/Uses/linux.mk
@@ -23,6 +23,8 @@
 _INCLUDE_USES_LINUX_MK=	yes
 _USES_POST+=		linux
 
+IGNORE=	Linux compatibility is not supported on CheriBSD yet
+
 .  if empty(linux_ARGS)
 .    if exists(${LINUXBASE}/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7)
 linux_ARGS=		c7


### PR DESCRIPTION
CheriBSD does not support Linux compatibility yet. When building packages, we shouldn't waste time processing Linux ports.