### PR TITLE
Fixes for math/gmp compiling under CheriABI.

### DIFF
--- a/math/gmp/files/patch-configfsf.sub
+++ b/math/gmp/files/patch-configfsf.sub
@@ -1,0 +1,11 @@
+--- configfsf.sub.orig	2022-11-16 14:08:32.274443000 +0000
++++ configfsf.sub	2022-11-15 11:38:56.465564000 +0000
+@@ -1158,7 +1158,7 @@
+ 		case $cpu in
+ 			1750a | 580 \
+ 			| a29k \
+-			| aarch64 | aarch64_be \
++			| aarch64 | aarch64c | aarch64_be \
+ 			| abacus \
+ 			| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] \
+ 			| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] \

--- a/math/gmp/files/patch-configure
+++ b/math/gmp/files/patch-configure
@@ -1,0 +1,47 @@
+--- configure.orig	2022-11-17 12:00:46.308994000 +0000
++++ configure	2022-11-17 12:09:40.609220000 +0000
+@@ -1550,8 +1550,8 @@
+               User-defined run-time library search path.
+   M4          m4 macro processor
+   YACC        The `Yet Another Compiler Compiler' implementation to use.
+-              Defaults to the first program found out of: `bison -y', `byacc',
+-              `yacc'.
++              Defaults to the first program found out of: `bison -o y.tab.c',
++              `byacc', `yacc'.
+   YFLAGS      The list of arguments that will be passed by default to $YACC.
+               This script will default YFLAGS to the empty string to avoid a
+               default value of `-d' given by some make applications.
+@@ -4257,7 +4257,6 @@
+     gcc_64_cflags_optlist="arch tune"
+     gcc_testlist="gcc-arm-umodsi"
+     gcc_64_testlist=""
+-    CALLING_CONVENTIONS_OBJS='arm32call.lo arm32check.lo'
+     CALLING_CONVENTIONS_OBJS_64=""
+     cclist_64="gcc cc"
+     any_32_testlist="sizeof-void*-4"
+@@ -4408,7 +4407,16 @@
+ 	gcc_cflags_neon="-mfpu=neon"
+ 	gcc_cflags_tune="-mtune=xgene1"
+ 	;;
++      aarch64c)
++        abilist="purecap"
++	path_64="arm64"
++	gcc_cflags_arch="-march=morello+c64"
++	gcc_cflags_neon=""
++	gcc_cflags_tune=""
++        gmp_asm_syntax_testing=no
++	;;
+       aarch64*)
++        CALLING_CONVENTIONS_OBJS='arm32call.lo arm32check.lo'
+         abilist="64 32"
+ 	path="arm/v7a/cora15/neon arm/neon arm/v7a/cora15 arm/v6t2 arm/v6 arm/v5 arm"
+ 	path_64="arm64"
+@@ -27748,7 +27756,7 @@
+ else
+   WITH_READLINE_01=0
+ fi
+-for ac_prog in 'bison -y' byacc
++for ac_prog in 'bison -o y.tab.c' byacc
+ do
+   # Extract the first word of "$ac_prog", so it can be a program name with args.
+ set dummy $ac_prog; ac_word=$2

--- a/math/gmp/files/patch-configure.ac
+++ b/math/gmp/files/patch-configure.ac
@@ -1,0 +1,27 @@
+--- configure.ac.orig	2022-11-16 14:04:13.224278000 +0000
++++ configure.ac	2022-11-17 12:09:35.925236000 +0000
+@@ -619,7 +619,6 @@
+     gcc_64_cflags_optlist="arch tune"
+     gcc_testlist="gcc-arm-umodsi"
+     gcc_64_testlist=""
+-    CALLING_CONVENTIONS_OBJS='arm32call.lo arm32check.lo'
+     CALLING_CONVENTIONS_OBJS_64=""
+     cclist_64="gcc cc"
+     any_32_testlist="sizeof-void*-4"
+@@ -770,7 +769,16 @@
+ 	gcc_cflags_neon="-mfpu=neon"
+ 	gcc_cflags_tune="-mtune=xgene1"
+ 	;;
++      aarch64c)
++        abilist="purecap"
++	path_64="arm64"
++	gcc_cflags_arch="-march=morello+c64"
++	gcc_cflags_neon=""
++	gcc_cflags_tune=""
++        gmp_asm_syntax_testing=no
++	;;
+       aarch64*)
++        CALLING_CONVENTIONS_OBJS='arm32call.lo arm32check.lo'
+         abilist="64 32"
+ 	path="arm/v7a/cora15/neon arm/neon arm/v7a/cora15 arm/v6t2 arm/v6 arm/v5 arm"
+ 	path_64="arm64"

--- a/math/gmp/files/patch-tests_memory.c
+++ b/math/gmp/files/patch-tests_memory.c
@@ -1,0 +1,63 @@
+--- tests/memory.c.orig	2022-11-16 14:13:51.451776000 +0000
++++ tests/memory.c	2022-11-15 18:16:41.820653000 +0000
+@@ -93,10 +93,10 @@
+   h->next = tests_memory_list;
+   tests_memory_list = h;
+ 
+-  rptr = __gmp_default_allocate (size + 2 * sizeof (mp_limb_t));
+-  ptr = (void *) ((gmp_intptr_t) rptr + sizeof (mp_limb_t));
++  rptr = __gmp_default_allocate (size + 2 * ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN));
++  ptr = (void *) ((gmp_intptr_t) rptr + ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN));
+ 
+-  *((mp_limb_t *) ((gmp_intptr_t) ptr - sizeof (mp_limb_t)))
++  *((mp_limb_t *) ((gmp_intptr_t) ptr - ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN)))
+     = PATTERN1 - PTRLIMB (ptr);
+   PATTERN2_var = PATTERN2 - PTRLIMB (ptr);
+   memcpy ((void *) ((gmp_intptr_t) ptr + size), &PATTERN2_var, sizeof (mp_limb_t));
+@@ -136,7 +136,7 @@
+       abort ();
+     }
+ 
+-  if (*((mp_limb_t *) ((gmp_intptr_t) ptr - sizeof (mp_limb_t)))
++  if (*((mp_limb_t *) ((gmp_intptr_t) ptr - ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN)))
+       != PATTERN1 - PTRLIMB (ptr))
+     {
+       fprintf (stderr, "in realloc: redzone clobbered before block\n");
+@@ -149,12 +149,12 @@
+       abort ();
+     }
+ 
+-  rptr = __gmp_default_reallocate ((void *) ((gmp_intptr_t) ptr - sizeof (mp_limb_t)),
+-				 old_size + 2 * sizeof (mp_limb_t),
+-				 new_size + 2 * sizeof (mp_limb_t));
+-  ptr = (void *) ((gmp_intptr_t) rptr + sizeof (mp_limb_t));
++  rptr = __gmp_default_reallocate ((void *) ((gmp_intptr_t) ptr - ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN)),
++				 old_size + 2 * ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN),
++				 new_size + 2 * ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN));
++  ptr = (void *) ((gmp_intptr_t) rptr + ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN));
+ 
+-  *((mp_limb_t *) ((gmp_intptr_t) ptr - sizeof (mp_limb_t)))
++  *((mp_limb_t *) ((gmp_intptr_t) ptr - ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN)))
+     = PATTERN1 - PTRLIMB (ptr);
+   PATTERN2_var = PATTERN2 - PTRLIMB (ptr);
+   memcpy ((void *) ((gmp_intptr_t) ptr + new_size), &PATTERN2_var, sizeof (mp_limb_t));
+@@ -186,7 +186,7 @@
+ 
+   *hp = h->next;  /* unlink */
+ 
+-  if (*((mp_limb_t *) ((gmp_intptr_t) ptr - sizeof (mp_limb_t)))
++  if (*((mp_limb_t *) ((gmp_intptr_t) ptr - ROUND_UP_MULTIPLE(sizeof (mp_limb_t), __TMP_ALIGN)))
+       != PATTERN1 - PTRLIMB (ptr))
+     {
+       fprintf (stderr, "in free: redzone clobbered before block\n");
+@@ -199,8 +199,8 @@
+       abort ();
+     }
+ 
+-  __gmp_default_free ((void *) ((gmp_intptr_t) ptr - sizeof(mp_limb_t)),
+-		      h->size + 2 * sizeof (mp_limb_t));
++  __gmp_default_free ((void *) ((gmp_intptr_t) ptr - ROUND_UP_MULTIPLE(sizeof(mp_limb_t), __TMP_ALIGN)),
++		      h->size + ROUND_UP_MULTIPLE(2 * sizeof (mp_limb_t), __TMP_ALIGN));
+   __gmp_default_free (h, sizeof (*h));
+ }
+ 


### PR DESCRIPTION
Fixes to `math/gmp` initially my focus is getting something that allows the v8 build to progress. Some points of discussion:

1) The relative merits of patching configure or running autoreconf on a patched configure.ac.

2) How to make this work for both hybrid and pure cap ABIs.