### PR TITLE
Fix startplasma-wayland

### DIFF
--- a/x11-servers/xwayland-devel/Makefile
+++ b/x11-servers/xwayland-devel/Makefile
@@ -67,6 +67,9 @@ DEFAULT_FONTPATH_LIST= \
 OPTIONS_DEFINE=	CSD NVIDIA
 OPTIONS_DEFAULT=CSD
 
+# libdecor needs cairo which isn't ported yet (needs to discover intptr_t)
+OPTIONS_EXCLUDE_purecap=	CSD
+
 CSD_DESC=		Client-side decorations via libdecor
 CSD_LIB_DEPENDS=	libdecor-0.so:x11-toolkits/libdecor
 CSD_MESON_TRUE=		libdecor

--- a/x11-toolkits/libXt/Makefile
+++ b/x11-toolkits/libXt/Makefile
@@ -3,6 +3,10 @@ DISTVERSION=	1.2.1
 PORTEPOCH=	1
 CATEGORIES=	x11-toolkits
 
+# CHERI support (merged upstream)
+PATCH_SITES=	https://gitlab.freedesktop.org/xorg/lib/libxt/-/merge_requests/
+PATCHFILES=	46.patch:-p1 47.patch:-p1
+
 MAINTAINER=	x11@FreeBSD.org
 COMMENT=	X Toolkit library
 WWW=		https://www.freedesktop.org/wiki/Software/xlibs/

--- a/x11-toolkits/libXt/distinfo
+++ b/x11-toolkits/libXt/distinfo
@@ -1,3 +1,7 @@
-TIMESTAMP = 1612385864
+TIMESTAMP = 1668629251
 SHA256 (xorg/lib/libXt-1.2.1.tar.bz2) = 679cc08f1646dbd27f5e48ffe8dd49406102937109130caab02ca32c083a3d60
 SIZE (xorg/lib/libXt-1.2.1.tar.bz2) = 784610
+SHA256 (xorg/lib/46.patch) = 2fc46db0d4c1739087d9768a215e1f9cb04b86721ec184cb5c93abf38caa926d
+SIZE (xorg/lib/46.patch) = 1188
+SHA256 (xorg/lib/47.patch) = 56018c69fe7622d09382f7ddd871ade132abe14516a22049a519b43f851e1a96
+SIZE (xorg/lib/47.patch) = 13084

--- a/x11-wm/plasma5-kwin/Makefile
+++ b/x11-wm/plasma5-kwin/Makefile
@@ -24,7 +24,9 @@ LIB_DEPENDS=	libXcursor.so:x11/libXcursor \
 		libxcb-image.so:x11/xcb-util-image \
 		libxcb-keysyms.so:x11/xcb-util-keysyms \
 		libxkbcommon.so:x11/libxkbcommon
-BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto
+BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto \
+		xwayland-devel>0:x11-servers/xwayland-devel
+RUN_DEPENDS=	xwayland-devel>0:x11-servers/xwayland-devel
 
 CONFLICTS_INSTALL=	kwinft # bin/kwin_wayland
 
@@ -56,8 +58,6 @@ OPTIONS_SUB=		yes
 .include <bsd.port.pre.mk>
 
 .if !${ABI:Mpurecap}
-BUILD_DEPENDS+=	xwayland-devel>0:x11-servers/xwayland-devel
-RUN_DEPENDS+=	xwayland-devel>0:x11-servers/xwayland-devel
 USES+=		gnome python:3.7+,run
 USE_QT+=	multimedia script
 .endif

--- a/x11/libX11/Makefile
+++ b/x11/libX11/Makefile
@@ -3,6 +3,10 @@ DISTVERSION=	1.7.2
 PORTEPOCH=	1
 CATEGORIES=	x11
 
+# CHERI support (merged upstream)
+PATCH_SITES=	https://gitlab.freedesktop.org/xorg/lib/libx11/-/merge_requests/
+PATCHFILES=	77.patch:-p1
+
 MAINTAINER=	x11@FreeBSD.org
 COMMENT=	X11 library
 WWW=		https://www.freedesktop.org/Software/xlibs

--- a/x11/libX11/distinfo
+++ b/x11/libX11/distinfo
@@ -1,3 +1,5 @@
-TIMESTAMP = 1623285146
+TIMESTAMP = 1668638777
 SHA256 (xorg/lib/libX11-1.7.2.tar.bz2) = 1cfa35e37aaabbe4792e9bb690468efefbfbf6b147d9c69d6f90d13c3092ea6c
 SIZE (xorg/lib/libX11-1.7.2.tar.bz2) = 2392982
+SHA256 (xorg/lib/77.patch) = ad6208d1c03402dd938349b06ff7caa97905333dc93903a53ba2de47e09edecd
+SIZE (xorg/lib/77.patch) = 2569

--- a/x11/libXrender/files/cheribsd.patch
+++ b/x11/libXrender/files/cheribsd.patch
@@ -1,0 +1,38 @@
+--- src/Xrender.c.orig	2022-11-17 00:04:44.572129000 +0000
++++ src/Xrender.c	2022-11-17 00:07:27.768743000 +0000
+@@ -414,6 +414,7 @@
+     int				nf, ns, nd, nv;
+     unsigned long		rlength;
+     unsigned long		nbytes;
++    unsigned long		padFormats;
+ 
+     RenderCheckExtension (dpy, info, 0);
+     LockDisplay (dpy);
+@@ -465,8 +466,17 @@
+ 	(rep.numVisuals < ((INT_MAX / 4) / sizeof (XRenderVisual))) &&
+ 	(rep.numSubpixel < ((INT_MAX / 4) / 4)) &&
+ 	(rep.length < (INT_MAX >> 2)) ) {
++	/*
++	 * XXX: Use proper generalised aligning, not hard-coded padding based
++	 * on struct layout and pointer size knowledge.
++	 */
++#ifdef __CHERI_PURE_CAPABILITY__
++	padFormats = rep.numFormats % 2;
++#else
++	padFormats = 0;
++#endif
+ 	xri = Xmalloc (sizeof (XRenderInfo) +
+-		       (rep.numFormats * sizeof (XRenderPictFormat)) +
++		       ((rep.numFormats + padFormats) * sizeof (XRenderPictFormat)) +
+ 		       (rep.numScreens * sizeof (XRenderScreen)) +
+ 		       (rep.numDepths * sizeof (XRenderDepth)) +
+ 		       (rep.numVisuals * sizeof (XRenderVisual)));
+@@ -496,7 +506,7 @@
+     xri->minor_version = async_state.minor_version;
+     xri->format = (XRenderPictFormat *) (xri + 1);
+     xri->nformat = rep.numFormats;
+-    xri->screen = (XRenderScreen *) (xri->format + rep.numFormats);
++    xri->screen = (XRenderScreen *) (xri->format + rep.numFormats + padFormats);
+     xri->nscreen = rep.numScreens;
+     xri->depth = (XRenderDepth *) (xri->screen + rep.numScreens);
+     xri->ndepth = rep.numDepths;

--- a/x11/plasma5-plasma-workspace/Makefile
+++ b/x11/plasma5-plasma-workspace/Makefile
@@ -61,6 +61,10 @@ OPTIONS_EXCLUDE_purecap=	BALOO QALCULATE CONSOLEKIT POLKIT
 # In 5.15 a file was moved from x11/plasma5-plasma-desktop to x11/plasma5-plasma-workspace:
 CONFLICTS_INSTALL=	plasma5-plasma-desktop-5.14.*
 
+post-patch:
+	@${REINPLACE_CMD} -e 's|%%LOCALBASE%%|${LOCALBASE}|g' \
+		${PATCH_WRKSRC}/startkde/startplasma.cpp
+
 post-stage:
 	${INSTALL_SCRIPT} ${FILESDIR}/startplasma-wayland.sh ${STAGEDIR}/${LOCALBASE}/bin/
 

--- a/x11/plasma5-plasma-workspace/files/cheribsd.patch
+++ b/x11/plasma5-plasma-workspace/files/cheribsd.patch
@@ -64,3 +64,20 @@ diff -ru shell/main.cpp shell/main.cpp
      // Plasma scales itself to font DPI
      // on X, where we don't have compositor scaling, this generally works fine.
      // also there are bugs on older Qt, especially when it comes to fractional scaling
+--- startkde/startplasma.cpp.orig	2022-07-11 12:02:54.000000000 +0100
++++ startkde/startplasma.cpp	2022-11-17 21:33:33.271277000 +0000
+@@ -363,6 +363,14 @@
+     const auto extraConfigDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation).toUtf8() + "/kdedefaults";
+     QDir().mkpath(QString::fromUtf8(extraConfigDir));
+     qputenv("XDG_CONFIG_DIRS", extraConfigDir + ":" + currentConfigDirs);
++
++    // Wayland sockets live in XDG_RUNTIME_DIR so make sure it's set. Other
++    // uses, including X applications, should have fallbacks, but can still
++    // benefit from it, and Qt will warn when it's not set.
++    if (!qEnvironmentVariableIsSet("XDG_RUNTIME_DIR")) {
++        const auto runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation).toUtf8();
++        qputenv("XDG_RUNTIME_DIR", runtimeDir);
++    }
+ 
+     const KConfig globals;
+     const QString currentLnf = KConfigGroup(&globals, QStringLiteral("KDE")).readEntry("LookAndFeelPackage", QStringLiteral("org.kde.breeze.desktop"));

--- a/x11/plasma5-plasma-workspace/files/patch-setup_xdg_environment
+++ b/x11/plasma5-plasma-workspace/files/patch-setup_xdg_environment
@@ -1,23 +1,11 @@
 --- startkde/startplasma.cpp.orig	2019-10-19 18:43:24.172713000 +0200
 +++ startkde/startplasma.cpp	2019-10-19 18:45:50.953945000 +0200
-@@ -192,6 +192,10 @@
-     if (!qEnvironmentVariableIsSet("XDG_DATA_DIRS")) {
-         qputenv("XDG_DATA_DIRS", KDE_INSTALL_FULL_DATAROOTDIR ":/usr/share:/usr/local/share");
+@@ -362,6 +362,6 @@
+     // Add kdedefaults dir to allow config defaults overriding from a writable location
+     QByteArray currentConfigDirs = qgetenv("XDG_CONFIG_DIRS");
+     if (currentConfigDirs.isEmpty()) {
+-        currentConfigDirs = "/etc/xdg";
++        currentConfigDirs = "%%LOCALBASE%%/etc/xdg:/etc/xdg";
      }
-+   // Additionally also set default value for XDG_CONFIG_DIRS which is not set by default on FreeBSD.
-+   if (!qEnvironmentVariableIsSet("XDG_CONFIG_DIRS")) {
-+        qputenv("XDG_CONFIG_DIRS", KDE_INSTALL_FULL_CONFDIR ":/etc/xdg:/usr/local/etc/xdg");
-+   }
- }
- 
- 
---- startkde/config-startplasma.h.cmake.orig	2019-10-19 18:56:51.844465000 +0200
-+++ startkde/config-startplasma.h.cmake	2019-10-19 18:57:22.843807000 +0200
-@@ -3,6 +3,7 @@
- 
- #define CMAKE_INSTALL_FULL_BINDIR "@CMAKE_INSTALL_FULL_BINDIR@"
- #define KDE_INSTALL_FULL_DATAROOTDIR "@KDE_INSTALL_FULL_DATAROOTDIR@"
-+#define KDE_INSTALL_FULL_CONFDIR "@KDE_INSTALL_FULL_CONFDIR@"
- #define CMAKE_INSTALL_FULL_LIBEXECDIR "@CMAKE_INSTALL_FULL_LIBEXECDIR@"
- #define CMAKE_INSTALL_FULL_LIBEXECDIR_KF5 "@CMAKE_INSTALL_FULL_LIBEXECDIR_KF5@"
- #define KWIN_WAYLAND_BIN_PATH "@KWIN_WAYLAND_BIN_PATH@"
+     const auto extraConfigDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation).toUtf8() + "/kdedefaults";
+     QDir().mkpath(QString::fromUtf8(extraConfigDir));


### PR DESCRIPTION
With these changes `dbus-run-session startplasma-wayland` (with the existing chmod hack due to a lack of proper seat management, since ConsoleKit requires GLib) can be used instead of the hacky minimal manual approach used before.