### PR TITLE
x11/plasma5-kactivitymanagerd: Add missing USE_QT=sql-sqlite3:run

### DIFF
--- a/x11/plasma5-kactivitymanagerd/Makefile
+++ b/x11/plasma5-kactivitymanagerd/Makefile
@@ -13,8 +13,8 @@ USES=		cmake compiler:c++11-lib gettext kde:5 qt:5 tar:xz xorg
 USE_KDE=	auth codecs config configwidgets coreaddons crash dbusaddons \
 		ecm globalaccel i18n kio service widgetsaddons windowsystem \
 		xmlgui
-USE_QT=		concurrent core dbus gui network sql widgets xml \
-		buildtools:build qmake:build
+USE_QT=		concurrent core dbus gui network sql sql-sqlite3:run widgets \
+		xml buildtools:build qmake:build
 USE_XORG=	x11
 
 .include <bsd.port.mk>


### PR DESCRIPTION
In a full KDE desktop qt5-sqldrivers-sqlite3 normally ends up being pulled in via a long chain of dependencies to qt5-help, which has it as an explicit dependency. However, in more minimal environments, we can end up with the package being missing, which causes kactivitymanagerd to immediately exit with a fatal error from being unable to open the database. If it exits too quickly this can even cause plasmashell to abort its startup, otherwise it leads to repeated kactivitymanagerd crashes that, by default, get reported by Dr Konqi as a flood of popups.