### PR TITLE
x11-wm/plasma5-kwin: Fix trusting processes on linprocfs-less FreeBSD

### DIFF
--- a/x11-wm/plasma5-kwin/files/cheribsd.patch
+++ b/x11-wm/plasma5-kwin/files/cheribsd.patch
@@ -199,3 +199,36 @@ diff -ru src/backends/fbdev/fb_backend.cpp src/backends/fbdev/fb_backend.cpp
      if (mem == MAP_FAILED) {
          qCWarning(KWIN_FB) << "Failed to mmap frame buffer";
          return;
+--- src/wayland_server.cpp.orig	2022-11-21 03:59:13.728342000 +0000
++++ src/wayland_server.cpp	2022-11-21 04:05:56.069510000 +0000
+@@ -78,6 +78,10 @@
+ // system
+ #include <sys/types.h>
+ #include <sys/socket.h>
++#ifdef __FreeBSD__
++#include <sys/param.h>
++#include <sys/sysctl.h>
++#endif
+ #include <unistd.h>
+ 
+ //screenlocker
+@@ -111,7 +115,18 @@
+ 
+     bool isTrustedOrigin(KWaylandServer::ClientConnection *client) const {
+         const auto fullPathSha = sha256(client->executablePath());
+-        const auto localSha = sha256(QLatin1String("/proc/") + QString::number(client->processId()) + QLatin1String("/exe"));
++#ifdef __FreeBSD__
++        const int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, static_cast<int>(client->processId())};
++        char buf[MAXPATHLEN];
++        size_t cb = sizeof(buf);
++        if (sysctl(mib, 4, buf, &cb, nullptr, 0) != 0) {
++            buf[0] = 0;
++        }
++        const auto localExe = QString::fromLocal8Bit(buf);
++#else
++        const auto localExe = QLatin1String("/proc/") + QString::number(client->processId()) + QLatin1String("/exe");
++#endif
++        const auto localSha = sha256(localExe);
+         const bool trusted = !localSha.isEmpty() && fullPathSha == localSha;
+ 
+         if (!trusted) {


### PR DESCRIPTION
Some of KWin's Wayland interfaces require the binary to be trusted, but the code to do this relies on a Linux-like procfs to be mounted. FreeBSD has linprocfs, so a workaround would be to mount that on FreeBSD, but it's currently tied to Linuxulator bits and doesn't get built on CHERI architectures in CheriBSD. Instead, change the code to use FreeBSD's sysctl equivalent with a slightly ugly patch.

This fixes Task Manager not knowing about any of the open windows, since the org_kde_plasma_window_management_interface interface it uses for that is one of the restricted interfaces, and so it would sit there forever waiting for its plasmaWindowManagementAnnounced callback to be invoked.

Note that in 5.26 KWaylandServer is merged into KWin itself and so we should instead reuse a generalised (to configure whether it does a readlink before returning) executablePathFromPid, since that already has a FreeBSD variant, and is where this code was copied from. Such a change should also be upstreamed.