### PR TITLE
SDDM and seatd support

### DIFF
--- a/sysutils/seatd/Makefile
+++ b/sysutils/seatd/Makefile
@@ -22,6 +22,8 @@ PLIST_FILES=	bin/${PORTNAME} \
 		lib/libseat.so.1 \
 		libdata/pkgconfig/libseat.pc
 
+EXTRA_PATCHES=	${PATCHDIR}/cpp.patch:-p1
+
 OPTIONS_DEFINE=	BASU MANPAGES
 OPTIONS_DEFAULT=BASU MANPAGES
 OPTIONS_SUB=	yes

--- a/sysutils/seatd/Makefile
+++ b/sysutils/seatd/Makefile
@@ -22,7 +22,8 @@ PLIST_FILES=	bin/${PORTNAME} \
 		lib/libseat.so.1 \
 		libdata/pkgconfig/libseat.pc
 
-EXTRA_PATCHES=	${PATCHDIR}/cpp.patch:-p1
+EXTRA_PATCHES=	${PATCHDIR}/cpp.patch:-p1 \
+		${PATCHDIR}/dri.patch:-p1
 
 OPTIONS_DEFINE=	BASU MANPAGES
 OPTIONS_DEFAULT=BASU MANPAGES

--- a/sysutils/seatd/Makefile
+++ b/sysutils/seatd/Makefile
@@ -26,6 +26,9 @@ OPTIONS_DEFINE=	BASU MANPAGES
 OPTIONS_DEFAULT=BASU MANPAGES
 OPTIONS_SUB=	yes
 
+# Not yet ported, and not needed since we lack ConsoleKit2
+OPTIONS_EXCLUDE_purecap=	BASU
+
 # https://lists.sr.ht/~kennylevinsen/seatd-devel/%3CQHZRRQ.73ZI29COPK131%40unrelenting.technology%3E
 BASU_DESC=		ConsoleKit2 support via basu (experimental)
 BASU_PATCH_SITES=	https://github.com/DankBSD/${PORTNAME}/commit/:ck2

--- a/sysutils/seatd/files/cpp.patch
+++ b/sysutils/seatd/files/cpp.patch
@@ -1,0 +1,30 @@
+commit 84b24bf7c1534f4c7967217b723b0560b20b36a3
+Author: Jessica Clarke <jrtc27@jrtc27.com>
+Date:   Tue Nov 22 05:44:44 2022 +0000
+
+    libseat: Allow library to be used from C++
+
+diff --git a/include/libseat.h b/include/libseat.h
+index 385acd9..e01786a 100644
+--- a/include/libseat.h
++++ b/include/libseat.h
+@@ -3,6 +3,10 @@
+ 
+ #include <stdarg.h>
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ /*
+  * An opaque struct containing an opened seat, created by libseat_open_seat and
+  * destroyed by libseat_close_seat.
+@@ -172,4 +176,8 @@ void libseat_set_log_handler(libseat_log_func handler);
+  */
+ void libseat_set_log_level(enum libseat_log_level level);
+ 
++#ifdef __cplusplus
++} /* extern "C" */
++#endif
++
+ #endif

--- a/sysutils/seatd/files/dri.patch
+++ b/sysutils/seatd/files/dri.patch
@@ -1,0 +1,50 @@
+commit 364bb7675a793a175a4db1d815b1541b29ec1714
+Author: Jessica Clarke <jrtc27@jrtc27.com>
+Date:   Wed Nov 23 02:12:42 2022 +0000
+
+    drm: Support drm-subtree drivers on FreeBSD
+    
+    The drm-kmod drivers use linuxkpi and end up with /dev/drm being the
+    canonical path for the devices, but the drm-subtree drivers use drmkpi
+    which has them appear under /dev/dri like Linux. Thus, adapt path_is_drm
+    to recognise both on FreeBSD.
+
+diff --git a/common/drm.c b/common/drm.c
+index 45ed7e5..cb57a0f 100644
+--- a/common/drm.c
++++ b/common/drm.c
+@@ -11,6 +11,7 @@
+ #define DRM_IOCTL_DROP_MASTER DRM_IO(0x1f)
+ 
+ #define STRLEN(s) ((sizeof(s) / sizeof(s[0])) - 1)
++#define STR_HAS_PREFIX(prefix, s) (strncmp(prefix, s, STRLEN(prefix)) == 0)
+ 
+ int drm_set_master(int fd) {
+ 	return ioctl(fd, DRM_IOCTL_SET_MASTER, 0);
+@@ -20,17 +21,16 @@ int drm_drop_master(int fd) {
+ 	return ioctl(fd, DRM_IOCTL_DROP_MASTER, 0);
+ }
+ 
+-#if defined(__linux__) || defined(__NetBSD__)
++#if defined(__linux__) || defined(__NetBSD__) || defined(__FreeBSD__)
+ int path_is_drm(const char *path) {
+-	static const char prefix[] = "/dev/dri/";
+-	static const int prefixlen = STRLEN(prefix);
+-	return strncmp(prefix, path, prefixlen) == 0;
+-}
+-#elif defined(__FreeBSD__)
+-int path_is_drm(const char *path) {
+-	static const char prefix[] = "/dev/drm/";
+-	static const int prefixlen = STRLEN(prefix);
+-	return strncmp(prefix, path, prefixlen) == 0;
++	if (STR_HAS_PREFIX("/dev/dri/", path))
++		return 1;
++#ifdef __FreeBSD__
++	/* Some drivers have /dev/dri/X symlinked to /dev/drm/X */
++	if (STR_HAS_PREFIX("/dev/drm/", path))
++		return 1;
++#endif
++	return 0;
+ }
+ #else
+ #error Unsupported platform

--- a/x11-wm/plasma5-kwin/Makefile
+++ b/x11-wm/plasma5-kwin/Makefile
@@ -51,9 +51,11 @@ USE_XORG=	ice sm x11 xcb xext xi
 SHEBANG_FILES=	kconf_update/*.py \
 		kconf_update/*.pl
 
-OPTIONS_DEFINE=		DOCS
-OPTIONS_DEFAULT=	DOCS
+OPTIONS_DEFINE=		DOCS LIBSEAT
+OPTIONS_DEFAULT=	DOCS LIBSEAT
 OPTIONS_SUB=		yes
+
+LIBSEAT_LIB_DEPENDS=	libseat.so:sysutils/seatd
 
 .include <bsd.port.pre.mk>
 

--- a/x11-wm/plasma5-kwin/files/cheribsd.patch
+++ b/x11-wm/plasma5-kwin/files/cheribsd.patch
@@ -232,3 +232,402 @@ diff -ru src/backends/fbdev/fb_backend.cpp src/backends/fbdev/fb_backend.cpp
          const bool trusted = !localSha.isEmpty() && fullPathSha == localSha;
  
          if (!trusted) {
+--- cmake/modules/FindLibseat.cmake.orig	2022-11-22 01:59:37.302917000 +0000
++++ cmake/modules/FindLibseat.cmake	2022-11-22 01:53:11.475968000 +0000
+@@ -0,0 +1,37 @@
++#.rst:
++# FindLibseat
++# -------
++#
++# Try to find libseat on a Unix system.
++#
++# This will define the following variables:
++#
++# ``Libseat_FOUND``
++#     True if (the requested version of) libseat is available
++# ``Libseat_VERSION``
++#     The version of libseat
++
++#=============================================================================
++# SPDX-FileCopyrightText: 2016 Martin Gräßlin <mgraesslin@kde.org>
++# SPDX-FileCopyrightText: 2021 Vlad Zahorodnii <vlad.zahorodnii@kde.org>
++# SPDX-FileCopyrightText: 2022 Jessica Clarke <jrtc27@jrtc27.com>
++#
++# SPDX-License-Identifier: BSD-3-Clause
++#=============================================================================
++
++find_package(PkgConfig)
++pkg_check_modules(PKG_libseat QUIET libseat)
++
++set(Libseat_VERSION ${PKG_libseat_VERSION})
++
++find_library(Libseat_LIBRARY NAMES seat HINTS ${PKG_Libseat_LIBRARY_DIRS})
++
++find_package_handle_standard_args(Libseat
++    FOUND_VAR Libseat_FOUND
++    REQUIRED_VARS Libseat_LIBRARY
++    VERSION_VAR Libseat_VERSION
++)
++
++mark_as_advanced(
++    Libseat_VERSION
++)
+--- CMakeLists.txt.orig	2022-07-11 11:52:25.000000000 +0100
++++ CMakeLists.txt	2022-11-22 04:07:08.361789000 +0000
+@@ -222,6 +222,11 @@
+     PURPOSE "Required for input handling on Wayland."
+ )
+ 
++find_package(Libseat)
++set_package_properties(Libseat PROPERTIES
++    TYPE OPTIONAL
++)
++
+ if (KWIN_BUILD_DRM_BACKEND OR HAVE_WAYLAND_EGL)
+     find_package(Libdrm 2.4.62)
+     set_package_properties(Libdrm PROPERTIES TYPE REQUIRED PURPOSE "Required for drm output on Wayland.")
+--- src/config-kwin.h.cmake.orig	2022-11-22 01:57:35.534476000 +0000
++++ src/config-kwin.h.cmake	2022-11-22 01:58:03.029351000 +0000
+@@ -46,3 +46,5 @@
+ #cmakedefine PipeWire_FOUND 1
+ 
+ #cmakedefine HAVE_XWAYLAND_LISTENFD
++
++#cmakedefine Libseat_FOUND 1
+--- src/CMakeLists.txt.orig	2022-11-22 01:36:09.794868000 +0000
++++ src/CMakeLists.txt	2022-11-22 01:58:20.269641000 +0000
+@@ -258,6 +258,11 @@
+     target_link_libraries(kwin Qt::GuiPrivate)
+ endif()
+ 
++if (Libseat_FOUND)
++    target_sources(kwin PRIVATE session_libseat.cpp)
++    target_link_libraries(kwin ${Libseat_LIBRARY})
++endif()
++
+ qt5_generate_dbus_interface(virtualkeyboard_dbus.h org.kde.kwin.VirtualKeyboard.xml OPTIONS -A)
+ qt5_generate_dbus_interface(tabletmodemanager.h org.kde.KWin.TabletModeManager.xml OPTIONS -A)
+ 
+--- src/session_libseat.cpp.orig	2022-11-22 04:53:36.562516000 +0000
++++ src/session_libseat.cpp	2022-11-22 05:01:42.498993000 +0000
+@@ -0,0 +1,216 @@
++/*
++    SPDX-FileCopyrightText: 2021 Vlad Zahorodnii <vlad.zahorodnii@kde.org>
++    SPDX-FileCopyrightText: 2022 Jessica Clarke <jrtc27@jrtc27.com>
++
++    SPDX-License-Identifier: GPL-2.0-or-later
++*/
++
++#include "session_libseat.h"
++#include "main.h"
++#include "utils/common.h"
++#include "wayland_server.h"
++
++#include <KWaylandServer/display.h>
++
++#include <fcntl.h>
++#include <string.h>
++#include <sys/stat.h>
++#include <unistd.h>
++
++#include <libseat.h>
++
++#include <wayland-server-core.h>
++
++namespace KWin
++{
++
++class LibseatSessionPrivate {
++public:
++    static void handleEnableSeat(struct libseat *seat, void *data)
++    {
++        LibseatSession *session = (LibseatSession *)data;
++        Q_EMIT session->handleEnableSeat();
++        Q_UNUSED(seat);
++    }
++
++    static void handleDisableSeat(struct libseat *seat, void *data)
++    {
++        LibseatSession *session = (LibseatSession *)data;
++        Q_EMIT session->handleDisableSeat();
++        Q_UNUSED(seat);
++    }
++};
++
++static const struct libseat_seat_listener s_listener = {
++    .enable_seat = &LibseatSessionPrivate::handleEnableSeat,
++    .disable_seat = &LibseatSessionPrivate::handleDisableSeat,
++};
++
++static int libseatEvent(int fd, uint32_t mask, void *data)
++{
++    struct libseat *seat = (struct libseat *)data;
++    if (libseat_dispatch(seat, 0) == -1) {
++        qCDebug(KWIN_CORE, "Failed to dispatch libseat event (%s)",
++                strerror(errno));
++    }
++    Q_UNUSED(fd);
++    Q_UNUSED(mask);
++    return 1;
++}
++
++LibseatSession *LibseatSession::create(QObject *parent)
++{
++    // We're lazy and abuse Wayland event loop since we don't care about
++    // X11, rather than dealing with creating our own thread as is used
++    // for D-Bus behind the scenes.
++    if (!waylandServer()) {
++        return nullptr;
++    }
++
++    LibseatSession *session = new LibseatSession(parent);
++    struct libseat *seat = libseat_open_seat(&s_listener, (void *)session);
++    if (!seat) {
++        delete session;
++        return nullptr;
++    }
++
++    struct wl_event_loop *eventLoop = wl_display_get_event_loop(*waylandServer()->display());
++    struct wl_event_source *eventSource =
++        wl_event_loop_add_fd(eventLoop, libseat_get_fd(seat), WL_EVENT_READABLE,
++                             libseatEvent, seat);
++    if (!eventSource) {
++        qCDebug(KWIN_CORE, "Failed to add libseat event source (%s)",
++                strerror(errno));
++        libseat_close_seat(seat);
++        delete session;
++        return nullptr;
++    }
++
++    if (libseat_dispatch(seat, 0) == -1) {
++        qCDebug(KWIN_CORE, "Failed to dispatch libseat event (%s)",
++                strerror(errno));
++        libseat_close_seat(seat);
++        wl_event_source_remove(eventSource);
++        delete session;
++        return nullptr;
++    }
++
++    session->initialize(seat, eventSource);
++    return session;
++}
++
++LibseatSession::LibseatSession(QObject *parent)
++    : Session(parent)
++    , m_seat(nullptr)
++    , m_eventSource(nullptr)
++{
++}
++
++void LibseatSession::initialize(struct libseat *seat, struct wl_event_source *eventSource)
++{
++    m_seat = seat;
++    m_eventSource = eventSource;
++}
++
++LibseatSession::~LibseatSession()
++{
++    if (m_seat) {
++        libseat_close_seat(m_seat);
++    }
++    if (m_eventSource) {
++        wl_event_source_remove(m_eventSource);
++    }
++}
++
++bool LibseatSession::isActive() const
++{
++    return m_isActive;
++}
++
++LibseatSession::Capabilities LibseatSession::capabilities() const
++{
++    return Capability::SwitchTerminal;
++}
++
++QString LibseatSession::seat() const
++{
++    return QString::fromUtf8(libseat_seat_name(m_seat));
++}
++
++uint LibseatSession::terminal() const
++{
++    return 0;
++}
++
++int LibseatSession::openRestricted(const QString &fileName)
++{
++    struct stat st;
++    if (stat(fileName.toUtf8(), &st) < 0) {
++        return -1;
++    }
++
++    int fileDescriptor;
++    int libseatId = libseat_open_device(m_seat, fileName.toUtf8(), &fileDescriptor);
++    if (libseatId == -1) {
++        qCDebug(KWIN_CORE, "Failed to open %s device (%s)",
++                qPrintable(fileName), strerror(errno));
++        return -1;
++    }
++
++    m_devices.push_back({libseatId, fileDescriptor, st.st_rdev});
++    return fileDescriptor;
++}
++
++void LibseatSession::closeRestricted(int fileDescriptor)
++{
++    auto it = std::find_if(m_devices.begin(), m_devices.end(),
++        [fileDescriptor](const LibseatDevice &device) {
++            return device.fileDescriptor == fileDescriptor;
++        }
++    );
++    if (it == m_devices.end()) {
++        qCDebug(KWIN_CORE, "Tried to close unknown device FD %d",
++                fileDescriptor);
++        close(fileDescriptor);
++        return;
++    }
++
++    libseat_close_device(m_seat, it->libseatId);
++    m_devices.erase(it);
++    close(fileDescriptor);
++}
++
++void LibseatSession::switchTo(uint terminal)
++{
++    if (libseat_switch_session(m_seat, terminal) == -1) {
++        qCDebug(KWIN_CORE, "Failed to switch to terminal %d (%s)",
++                terminal, strerror(errno));
++    }
++}
++
++void LibseatSession::updateActive(bool active)
++{
++    if (m_isActive != active) {
++        m_isActive = active;
++        Q_EMIT activeChanged(active);
++    }
++}
++
++void LibseatSession::handleEnableSeat()
++{
++    for (const LibseatDevice &device : m_devices) {
++        Q_EMIT deviceResumed(device.deviceId);
++    }
++    updateActive(true);
++}
++
++void LibseatSession::handleDisableSeat()
++{
++    updateActive(false);
++    for (const LibseatDevice &device : m_devices) {
++        Q_EMIT devicePaused(device.deviceId);
++    }
++    libseat_disable_seat(m_seat);
++}
++
++} // namespace KWin
+--- src/session_libseat.h.orig	2022-11-22 04:53:36.563592000 +0000
++++ src/session_libseat.h	2022-11-22 04:58:40.901318000 +0000
+@@ -0,0 +1,65 @@
++/*
++    SPDX-FileCopyrightText: 2021 Vlad Zahorodnii <vlad.zahorodnii@kde.org>
++    SPDX-FileCopyrightText: 2022 Jessica Clarke <jrtc27@jrtc27.com>
++
++    SPDX-License-Identifier: GPL-2.0-or-later
++*/
++
++#pragma once
++
++#include "session.h"
++
++struct libseat;
++struct wl_event_source;
++
++namespace KWin
++{
++
++namespace Wayland
++{
++class WaylandBackend;
++}
++
++class LibseatSessionPrivate;
++
++class LibseatSession : public Session
++{
++    Q_OBJECT
++
++    struct LibseatDevice {
++        int libseatId;
++        int fileDescriptor;
++        dev_t deviceId;
++    };
++
++public:
++    static LibseatSession *create(QObject *parent = nullptr);
++    ~LibseatSession() override;
++
++    bool isActive() const override;
++    Capabilities capabilities() const override;
++    QString seat() const override;
++    uint terminal() const override;
++    int openRestricted(const QString &fileName) override;
++    void closeRestricted(int fileDescriptor) override;
++    void switchTo(uint terminal) override;
++
++private Q_SLOTS:
++    void handleEnableSeat();
++    void handleDisableSeat();
++
++private:
++    explicit LibseatSession(QObject *parent = nullptr);
++
++    void initialize(struct libseat *seat, struct wl_event_source *eventSource);
++    void updateActive(bool active);
++
++    struct libseat *m_seat;
++    struct wl_event_source *m_eventSource;
++    QList<LibseatDevice> m_devices;
++    bool m_isActive = false;
++
++    friend class LibseatSessionPrivate;
++};
++
++} // namespace KWin
+--- src/session.cpp.orig	2022-11-22 04:03:50.987686000 +0000
++++ src/session.cpp	2022-11-22 04:05:38.058479000 +0000
+@@ -5,7 +5,13 @@
+ */
+ 
+ #include "session.h"
++
++#include <config-kwin.h>
++
+ #include "session_consolekit.h"
++#ifdef Libseat_FOUND
++#include "session_libseat.h"
++#endif
+ #include "session_logind.h"
+ #include "session_noop.h"
+ 
+@@ -18,6 +20,9 @@
+ } s_availableSessions[] = {
+     { Session::Type::Logind, &LogindSession::create },
+     { Session::Type::ConsoleKit, &ConsoleKitSession::create },
++#ifdef Libseat_FOUND
++    { Session::Type::Libseat, &LibseatSession::create },
++#endif
+     { Session::Type::Noop, &NoopSession::create },
+ };
+ 
+--- src/session.h.orig	2022-11-22 04:05:52.236773000 +0000
++++ src/session.h	2022-11-22 04:06:39.247407000 +0000
+@@ -34,6 +34,7 @@
+     enum class Type {
+         Noop,
+         ConsoleKit,
++        Libseat,
+         Logind,
+     };
+ 

--- a/x11/cheri-desktop/Makefile
+++ b/x11/cheri-desktop/Makefile
@@ -20,6 +20,7 @@ RUN_DEPENDS+=	${LOCALBASE}/bin/konsole:x11/konsole
 RUN_DEPENDS+=	${LOCALBASE}/bin/kwin_wayland:x11-wm/plasma5-kwin
 RUN_DEPENDS+=	${LOCALBASE}/bin/okular:graphics/okular
 RUN_DEPENDS+=	${LOCALBASE}/bin/plasmashell:x11/plasma5-plasma-workspace
+RUN_DEPENDS+=	${LOCALBASE}/bin/sddm:x11/sddm
 RUN_DEPENDS+=	${LOCALBASE}/bin/seatd:sysutils/seatd
 RUN_DEPENDS+=	${LOCALBASE}/lib/libEGL.so:graphics/libglvnd
 RUN_DEPENDS+=	${LOCALBASE}/lib/libEGL_mesa.so:graphics/mesa-libs

--- a/x11/cheri-desktop/Makefile
+++ b/x11/cheri-desktop/Makefile
@@ -20,6 +20,7 @@ RUN_DEPENDS+=	${LOCALBASE}/bin/konsole:x11/konsole
 RUN_DEPENDS+=	${LOCALBASE}/bin/kwin_wayland:x11-wm/plasma5-kwin
 RUN_DEPENDS+=	${LOCALBASE}/bin/okular:graphics/okular
 RUN_DEPENDS+=	${LOCALBASE}/bin/plasmashell:x11/plasma5-plasma-workspace
+RUN_DEPENDS+=	${LOCALBASE}/bin/seatd:sysutils/seatd
 RUN_DEPENDS+=	${LOCALBASE}/lib/libEGL.so:graphics/libglvnd
 RUN_DEPENDS+=	${LOCALBASE}/lib/libEGL_mesa.so:graphics/mesa-libs
 RUN_DEPENDS+=	${LOCALBASE}/lib/libKF5Plasma.so:x11/kf5-plasma-framework

--- a/x11/cheri-desktop/Makefile
+++ b/x11/cheri-desktop/Makefile
@@ -40,4 +40,13 @@ RUN_DEPENDS+=	${LOCALBASE}/share/wallpapers/Elarun/metadata.desktop:x11-themes/p
 RUN_DEPENDS+=	${LOCALBASE}/lib/dri/panfrost_dri.so:graphics/mesa-dri
 .endif
 
+SUB_FILES=	sddm \
+		seatd
+
+post-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/etc/rc.conf.d
+	${INSTALL_DATA} ${FILESDIR}/cheri-desktop ${STAGEDIR}${PREFIX}/etc/rc.conf.d
+	${INSTALL_DATA} ${WRKDIR}/sddm ${STAGEDIR}${PREFIX}/etc/rc.conf.d
+	${INSTALL_DATA} ${WRKDIR}/seatd ${STAGEDIR}${PREFIX}/etc/rc.conf.d
+
 .include <bsd.port.mk>

--- a/x11/cheri-desktop/files/cheri-desktop
+++ b/x11/cheri-desktop/files/cheri-desktop
@@ -1,0 +1,1 @@
+: ${cheri_desktop_enable:=YES}

--- a/x11/cheri-desktop/files/sddm.in
+++ b/x11/cheri-desktop/files/sddm.in
@@ -1,0 +1,2 @@
+. "%%PREFIX%%/etc/rc.conf.d/cheri-desktop"
+sddm_enable_defval="${cheri_desktop_enable}"

--- a/x11/cheri-desktop/files/seatd.in
+++ b/x11/cheri-desktop/files/seatd.in
@@ -1,0 +1,2 @@
+. "%%PREFIX%%/etc/rc.conf.d/cheri-desktop"
+seatd_enable_defval="${cheri_desktop_enable}"

--- a/x11/cheri-desktop/pkg-plist
+++ b/x11/cheri-desktop/pkg-plist
@@ -1,0 +1,3 @@
+etc/rc.conf.d/cheri-desktop
+etc/rc.conf.d/sddm
+etc/rc.conf.d/seatd

--- a/x11/sddm/Makefile
+++ b/x11/sddm/Makefile
@@ -20,12 +20,18 @@ LICENSE_COMB=	multi
 LICENSE_FILE_GPLv2+ =	${WRKSRC}/LICENSE
 LICENSE_FILE_CC-BY-3.0=	${WRKSRC}/LICENSE.CC-BY-3.0
 
-BUILD_DEPENDS=	rst2man.py-${PYTHON_VER}:textproc/py-docutils@${PY_FLAVOR}
+OPTIONS_DEFINE=	DOCS
+OPTIONS_SUB=	yes
+
+OPTIONS_DEFAULT=	DOCS
+
+DOCS_BUILD_DEPENDS=	rst2man.py-${PYTHON_VER}:textproc/py-docutils@${PY_FLAVOR}
 RUN_DEPENDS=	dbus-run-session:devel/dbus \
 		xauth:x11/xauth \
 		xmessage:x11/xmessage
 
-USES=		cmake compiler:c++11-lang cpe kde:5 pkgconfig python:build qt:5 xorg
+USES=		cmake compiler:c++11-lang cpe kde:5 pkgconfig qt:5 xorg
+DOCS_USES=	python:build
 CPE_VENDOR=	${PORTNAME}_project
 USE_GITHUB=	yes
 USE_KDE=	ecm:build
@@ -35,11 +41,12 @@ USE_XORG=	xcb
 
 CONFLICTS_INSTALL=	lightdm
 
-CMAKE_ON=	BUILD_MAN_PAGES
 CMAKE_ARGS=	-DUID_MIN=1000 \
 		-DUID_MAX=65000 \
-		-DCMAKE_INSTALL_SYSCONFDIR:PATH=${LOCALBASE}/etc \
-		-DRST2MAN_EXECUTABLE=${LOCALBASE}/bin/rst2man.py-${PYTHON_VER}
+		-DCMAKE_INSTALL_SYSCONFDIR:PATH=${LOCALBASE}/etc
+
+DOCS_CMAKE_ON=	BUILD_MAN_PAGES
+DOCS_CMAKE_ARGS=	-DRST2MAN_EXECUTABLE=${LOCALBASE}/bin/rst2man.py-${PYTHON_VER}
 
 USE_RC_SUBR=	sddm
 SUB_FILES=	xinitrc.desktop

--- a/x11/sddm/files/cheribsd.patch
+++ b/x11/sddm/files/cheribsd.patch
@@ -1,0 +1,183 @@
+--- src/common/VirtualTerminal.cpp.orig	2020-11-03 09:55:31.000000000 +0000
++++ src/common/VirtualTerminal.cpp	2022-11-26 21:05:15.164612000 +0000
+@@ -27,8 +27,12 @@
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <signal.h>
++#ifdef __FreeBSD__
++#include <sys/consio.h>
++#else
+ #include <linux/vt.h>
+ #include <linux/kd.h>
++#endif
+ #include <sys/ioctl.h>
+ 
+ #define RELEASE_DISPLAY_SIGNAL (SIGRTMAX)
+@@ -36,14 +40,29 @@
+ 
+ namespace SDDM {
+     namespace VirtualTerminal {
++#ifdef __FreeBSD__
++        static const char *defaultVtPath = "/dev/ttyv0";
++
++        QString getVtPath(int vt) {
++            char c = (vt <= 10 ? '0' : 'a') + (vt - 1);
++            return QStringLiteral("/dev/ttyv%1").arg(c);
++        }
++#else
++        static const char *defaultVtPath = "/dev/tty0";
++
++        QString getVtPath(int vt) {
++            return QStringLiteral("/dev/tty%1").arg(vt);
++        }
++#endif
++
+         static void onAcquireDisplay(int signal) {
+-            int fd = open("/dev/tty0", O_RDWR | O_NOCTTY);
++            int fd = open(defaultVtPath, O_RDWR | O_NOCTTY);
+             ioctl(fd, VT_RELDISP, VT_ACKACQ);
+             close(fd);
+         }
+ 
+         static void onReleaseDisplay(int signal) {
+-            int fd = open("/dev/tty0", O_RDWR | O_NOCTTY);
++            int fd = open(defaultVtPath, O_RDWR | O_NOCTTY);
+             ioctl(fd, VT_RELDISP, 1);
+             close(fd);
+         }
+@@ -117,18 +136,28 @@
+ 
+         int setUpNewVt() {
+             // open VT master
+-            int fd = open("/dev/tty0", O_RDWR | O_NOCTTY);
++            int fd = open(defaultVtPath, O_RDWR | O_NOCTTY);
+             if (fd < 0) {
+                 qCritical() << "Failed to open VT master:" << strerror(errno);
+                 return -1;
+             }
+ 
++#ifdef __FreeBSD__
++            int vtActive = 0;
++            if (ioctl(fd, VT_GETACTIVE, &vtActive) < 0) {
++                qCritical() << "Failed to get current VT:" << strerror(errno);
++                close(fd);
++                return -1;
++            }
++#else
+             vt_stat vtState = { 0 };
+             if (ioctl(fd, VT_GETSTATE, &vtState) < 0) {
+                 qCritical() << "Failed to get current VT:" << strerror(errno);
+                 close(fd);
+                 return -1;
+             }
++            int vtActive = vtState.v_active;
++#endif
+ 
+             int vt = 0;
+             if (ioctl(fd, VT_OPENQRY, &vt) < 0) {
+@@ -141,8 +170,8 @@
+ 
+             // fallback to active VT
+             if (vt <= 0) {
+-                qWarning() << "New VT" << vt << "is not valid, fall back to" << vtState.v_active;
+-                return vtState.v_active;
++                qWarning() << "New VT" << vt << "is not valid, fall back to" << vtActive;
++                return vtActive;
+             }
+ 
+             return vt;
+@@ -153,9 +182,9 @@
+ 
+             int fd;
+ 
+-            int activeVtFd = open("/dev/tty0", O_RDWR | O_NOCTTY);
++            int activeVtFd = open(defaultVtPath, O_RDWR | O_NOCTTY);
+ 
+-            QString ttyString = QStringLiteral("/dev/tty%1").arg(vt);
++            QString ttyString = getVtPath(vt);
+             int vtFd = open(qPrintable(ttyString), O_RDWR | O_NOCTTY);
+             if (vtFd != -1) {
+                 fd = vtFd;
+@@ -171,7 +200,7 @@
+                 fixVtMode(activeVtFd, vt_auto);
+             } else {
+                 qWarning("Failed to open %s: %s", qPrintable(ttyString), strerror(errno));
+-                qDebug("Using /dev/tty0 instead of %s!", qPrintable(ttyString));
++                qDebug("Using %s instead of %s!", defaultVtPath, qPrintable(ttyString));
+                 fd = activeVtFd;
+             }
+ 
+--- src/common/VirtualTerminal.h.orig	2022-11-26 21:03:34.680909000 +0000
++++ src/common/VirtualTerminal.h	2022-11-26 21:05:10.901276000 +0000
+@@ -22,6 +22,7 @@
+ 
+ namespace SDDM {
+     namespace VirtualTerminal {
++        QString getVtPath(int vt);
+         int setUpNewVt();
+         void jumpToVt(int vt, bool vt_auto);
+     }
+--- src/daemon/CMakeLists.txt.orig	2020-11-03 09:55:31.000000000 +0000
++++ src/daemon/CMakeLists.txt	2022-11-26 02:52:38.410116000 +0000
+@@ -31,13 +31,7 @@
+     SocketServer.cpp
+ )
+ 
+-# Different implementations of the VT switching code
+-# (where the FreeBSD version does nothing).
+-if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
+-    list(APPEND DAEMON_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal_FreeBSD.cpp)
+-else()
+-    list(APPEND DAEMON_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
+-endif()
++list(APPEND DAEMON_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
+ 
+ qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.xml"          "DisplayManager.h" SDDM::DisplayManager)
+ qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Seat.xml"     "DisplayManager.h" SDDM::DisplayManagerSeat)
+--- src/helper/CMakeLists.txt.orig	2020-11-03 09:55:31.000000000 +0000
++++ src/helper/CMakeLists.txt	2022-11-26 02:52:38.410292000 +0000
+@@ -15,13 +15,7 @@
+     UserSession.cpp
+ )
+ 
+-# Different implementations of the VT switching code
+-# (where the FreeBSD version does nothing).
+-if(${CMAKE_SYSTEM} MATCHES "FreeBSD")
+-    list(APPEND HELPER_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal_FreeBSD.cpp)
+-else()
+-    list(APPEND HELPER_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
+-endif()
++list(APPEND HELPER_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
+ 
+ if(PAM_FOUND)
+     set(HELPER_SOURCES
+--- src/helper/UserSession.cpp.orig	2020-11-03 09:55:31.000000000 +0000
++++ src/helper/UserSession.cpp	2022-11-26 21:05:48.133615000 +0000
+@@ -82,7 +82,7 @@
+         if (sessionType == QLatin1String("wayland")) {
+             // open VT and get the fd
+             int vtNumber = processEnvironment().value(QStringLiteral("XDG_VTNR")).toInt();
+-            QString ttyString = QStringLiteral("/dev/tty%1").arg(vtNumber);
++            QString ttyString = VirtualTerminal::getVtPath(vtNumber);
+             int vtFd = ::open(qPrintable(ttyString), O_RDWR | O_NOCTTY);
+ 
+             // when this is true we'll take control of the tty
+--- src/helper/backend/PamBackend.cpp.orig	2022-11-26 21:03:28.044383000 +0000
++++ src/helper/backend/PamBackend.cpp	2022-11-26 21:06:34.443847000 +0000
+@@ -23,6 +23,7 @@
+ #include "HelperApp.h"
+ #include "UserSession.h"
+ #include "Auth.h"
++#include "VirtualTerminal.h"
+ 
+ #include <QtCore/QString>
+ #include <QtCore/QDebug>
+@@ -257,7 +258,7 @@
+                 m_pam->setItem(PAM_TTY, qPrintable(display));
+             }
+         } else if (sessionEnv.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("wayland")) {
+-            QString tty = QStringLiteral("/dev/tty%1").arg(sessionEnv.value(QStringLiteral("XDG_VTNR")));
++            QString tty = VirtualTerminal::getVtPath(sessionEnv.value(QStringLiteral("XDG_VTNR")).toInt());
+             m_pam->setItem(PAM_TTY, qPrintable(tty));
+         }
+ 

--- a/x11/sddm/pkg-plist
+++ b/x11/sddm/pkg-plist
@@ -18,10 +18,10 @@ etc/dbus-1/system.d/org.freedesktop.DisplayManager.conf
 %%QT_QMLDIR%%/SddmComponents/qmldir
 %%QT_QMLDIR%%/SddmComponents/warning.png
 libexec/sddm-helper
-share/man/man1/sddm-greeter.1.gz
-share/man/man1/sddm.1.gz
-share/man/man5/sddm-state.conf.5.gz
-share/man/man5/sddm.conf.5.gz
+%%DOCS%%share/man/man1/sddm-greeter.1.gz
+%%DOCS%%share/man/man1/sddm.1.gz
+%%DOCS%%share/man/man5/sddm-state.conf.5.gz
+%%DOCS%%share/man/man5/sddm.conf.5.gz
 %%DATADIR%%/faces/.face.icon
 %%DATADIR%%/faces/root.face.icon
 %%DATADIR%%/flags/ae.png


### PR DESCRIPTION
This adds support for two things:
* So long as a user is in the video group they no longer need to chmod/chown any input devices from root-only in order to be able to run KWin, as they can now access them via seatd
* Users can log in via SDDM rather than logging into a console and running a command to start KDE

The services are also auto-started by default, with a global cheri_desktop_enable="YES/NO" to control them both (or they can be controlled individually too if desired, but users shouldn't do that in case we add to the set of packages later and introduce new things that need enabling for a desktop environment).