### PR TITLE
Various GUI fixes

### DIFF
--- a/x11-servers/xorg-server/files/cheribsd.patch
+++ b/x11-servers/xorg-server/files/cheribsd.patch
@@ -1,0 +1,22 @@
+--- record/set.c.orig	2022-12-06 01:06:34.235410000 +0000
++++ record/set.c	2022-12-06 01:08:13.986016000 +0000
+@@ -179,7 +179,8 @@
+ {
+     int nlongs;
+ 
+-    *alignment = sizeof(unsigned long);
++    /* XXX: Proper _Alignof? */
++    *alignment = max(sizeof(unsigned long), sizeof(void *));
+     nlongs = (maxMember + BITS_PER_LONG) / BITS_PER_LONG;
+     return (sizeof(BitVectorSet) + nlongs * sizeof(unsigned long));
+ }
+@@ -289,7 +290,8 @@
+ IntervalListMemoryRequirements(RecordSetInterval * pIntervals, int nIntervals,
+                                int maxMember, int *alignment)
+ {
+-    *alignment = sizeof(unsigned long);
++    /* XXX: Proper _Alignof? */
++    *alignment = max(sizeof(unsigned long), sizeof(void *));
+     return sizeof(IntervalListSet) + nIntervals * sizeof(RecordSetInterval);
+ }
+ 

--- a/x11-servers/xwayland-devel/files/cheribsd.patch
+++ b/x11-servers/xwayland-devel/files/cheribsd.patch
@@ -1,0 +1,123 @@
+diff --git hw/xwayland/xwayland-present.c hw/xwayland/xwayland-present.c
+index 99e476b2f..897096113 100644
+--- hw/xwayland/xwayland-present.c
++++ hw/xwayland/xwayland-present.c
+@@ -47,6 +47,8 @@
+ #define TIMER_LEN_COPY      17  // ~60fps
+ #define TIMER_LEN_FLIP    1000  // 1fps
+ 
++static uint64_t xwl_present_event_id;
++
+ static DevPrivateKeyRec xwl_present_window_private_key;
+ 
+ static struct xwl_present_window *
+@@ -84,9 +86,23 @@ xwl_present_window_get_priv(WindowPtr window)
+ }
+ 
+ static struct xwl_present_event *
+-xwl_present_event_from_id(uint64_t event_id)
++xwl_present_event_from_id(WindowPtr present_window,
++                          uint64_t event_id)
+ {
+-    return (struct xwl_present_event*)(uintptr_t)event_id;
++    present_window_priv_ptr     window_priv = present_get_window_priv(present_window, TRUE);
++    struct xwl_present_event    *event;
++
++    xorg_list_for_each_entry(event, &window_priv->vblank, vblank.window_list) {
++        if (event->vblank.event_id == event_id)
++            return event;
++    }
++    return NULL;
++}
++
++static struct xwl_present_event *
++xwl_present_event_from_vblank(present_vblank_ptr vblank)
++{
++    return container_of(vblank, struct xwl_present_event, vblank);
+ }
+ 
+ static void
+@@ -241,7 +257,7 @@ static void
+ xwl_present_free_idle_vblank(present_vblank_ptr vblank)
+ {
+     present_pixmap_idle(vblank->pixmap, vblank->window, vblank->serial, vblank->idle_fence);
+-    xwl_present_free_event(xwl_present_event_from_id((uintptr_t)vblank));
++    xwl_present_free_event(xwl_present_event_from_vblank(vblank));
+ }
+ 
+ static WindowPtr
+@@ -279,7 +295,7 @@ xwl_present_flips_stop(WindowPtr window)
+         struct xwl_present_event *event;
+ 
+         vblank = xwl_present_window->flip_active;
+-        event = xwl_present_event_from_id((uintptr_t)vblank);
++        event = xwl_present_event_from_vblank(vblank);
+         if (event->pixmap)
+             xwl_present_free_idle_vblank(vblank);
+         else
+@@ -308,7 +324,7 @@ xwl_present_flip_notify_vblank(present_vblank_ptr vblank, uint64_t ust, uint64_t
+ 
+     if (xwl_present_window->flip_active) {
+         struct xwl_present_event *event =
+-            xwl_present_event_from_id((uintptr_t)xwl_present_window->flip_active);
++            xwl_present_event_from_vblank(xwl_present_window->flip_active);
+ 
+         if (!event->pixmap)
+             xwl_present_free_event(event);
+@@ -509,7 +525,12 @@ xwl_present_queue_vblank(ScreenPtr screen,
+ {
+     struct xwl_present_window *xwl_present_window = xwl_present_window_get_priv(present_window);
+     struct xwl_window *xwl_window = xwl_window_from_window(present_window);
+-    struct xwl_present_event *event = xwl_present_event_from_id(event_id);
++    struct xwl_present_event *event = xwl_present_event_from_id(present_window, event_id);
++
++    if (!event) {
++        ErrorF("present: Error getting event\n");
++        return BadImplementation;
++    }
+ 
+     event->vblank.exec_msc = msc;
+ 
+@@ -678,18 +699,17 @@ xwl_present_clear_window_flip(WindowPtr window)
+ }
+ 
+ static Bool
+-xwl_present_flip(WindowPtr present_window,
+-                 RRCrtcPtr crtc,
+-                 uint64_t event_id,
+-                 PixmapPtr pixmap,
+-                 Bool sync_flip,
++xwl_present_flip(present_vblank_ptr vblank,
+                  RegionPtr damage)
+ {
++    WindowPtr                   present_window = vblank->window;
++    PixmapPtr                   pixmap = vblank->pixmap;
++    Bool                        sync_flip = vblank->sync_flip;
+     struct xwl_window           *xwl_window = xwl_window_from_window(present_window);
+     struct xwl_present_window   *xwl_present_window = xwl_present_window_priv(present_window);
+     BoxPtr                      damage_box;
+     struct wl_buffer            *buffer;
+-    struct xwl_present_event    *event = xwl_present_event_from_id(event_id);
++    struct xwl_present_event    *event = xwl_present_event_from_vblank(vblank);
+ 
+     if (!xwl_window)
+         return FALSE;
+@@ -791,8 +811,7 @@ xwl_present_execute(present_vblank_ptr vblank, uint64_t ust, uint64_t crtc_msc)
+             } else
+                 damage = RegionDuplicate(&window->clipList);
+ 
+-            if (xwl_present_flip(vblank->window, vblank->crtc, vblank->event_id,
+-                                 vblank->pixmap, vblank->sync_flip, damage)) {
++            if (xwl_present_flip(vblank, damage)) {
+                 WindowPtr toplvl_window = xwl_present_toplvl_pixmap_window(vblank->window);
+                 PixmapPtr old_pixmap = screen->GetWindowPixmap(window);
+ 
+@@ -927,7 +946,7 @@ xwl_present_pixmap(WindowPtr window,
+         return BadAlloc;
+     }
+ 
+-    vblank->event_id = (uintptr_t)event;
++    vblank->event_id = ++xwl_present_event_id;
+ 
+     /* Xwayland presentations always complete (at least) one frame after they
+      * are executed

--- a/x11/libXi/files/cheribsd.patch
+++ b/x11/libXi/files/cheribsd.patch
@@ -1,0 +1,15 @@
+--- src/XListDev.c.orig	2022-12-06 00:00:03.974874000 +0000
++++ src/XListDev.c	2022-12-06 00:04:01.417798000 +0000
+@@ -68,7 +68,11 @@
+  */
+ static int pad_to_xid(int base_size)
+ {
+-    int padsize = sizeof(XID);
++    /*
++     * XXX: XValuatorInfo contains a pointer so needs more than XID padding
++     * XXX: Do proper _Alignof (polyfill via offsetof)?
++     */
++    int padsize = sizeof(void *) > sizeof(XID) ? sizeof(void *) : sizeof(XID);
+ 
+     return ((base_size + padsize - 1)/padsize) * padsize;
+ }

--- a/x11/plasma5-plasma-workspace/files/cheribsd.patch
+++ b/x11/plasma5-plasma-workspace/files/cheribsd.patch
@@ -66,7 +66,7 @@ diff -ru shell/main.cpp shell/main.cpp
      // also there are bugs on older Qt, especially when it comes to fractional scaling
 --- startkde/startplasma.cpp.orig	2022-07-11 12:02:54.000000000 +0100
 +++ startkde/startplasma.cpp	2022-11-17 21:33:33.271277000 +0000
-@@ -363,6 +363,14 @@
+@@ -363,6 +363,20 @@
      const auto extraConfigDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation).toUtf8() + "/kdedefaults";
      QDir().mkpath(QString::fromUtf8(extraConfigDir));
      qputenv("XDG_CONFIG_DIRS", extraConfigDir + ":" + currentConfigDirs);
@@ -78,6 +78,12 @@ diff -ru shell/main.cpp shell/main.cpp
 +        const auto runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation).toUtf8();
 +        qputenv("XDG_RUNTIME_DIR", runtimeDir);
 +    }
++
++#ifdef __CHERI_PURE_CAPABILITY__
++    if (!qEnvironmentVariableIsSet("XDG_DATA_DIRS")) {
++        qputenv("XDG_DATA_DIRS", "/usr/local/share:/usr/local64/share:/usr/share");
++    }
++#endif
  
      const KConfig globals;
      const QString currentLnf = KConfigGroup(&globals, QStringLiteral("KDE")).readEntry("LookAndFeelPackage", QStringLiteral("org.kde.breeze.desktop"));


### PR DESCRIPTION
Plasma (X11) still doesn't work when selected as kwin_x11 times out trying to use GL compositing and restarts itself without compositing, but things no longer core dump so X in general (for things that want to use Xwayland) is likely in better shape than it was. Not sure why X11 compositing isn't working, something about SYNC extension fences never getting triggered from kwin's perspective, but we don't actually need it to work.