### PR TITLE
Firefox patches

### DIFF
--- a/www/firefox/Makefile
+++ b/www/firefox/Makefile
@@ -34,9 +34,12 @@ CFLAGS_powerpc64le=	-DSQLITE_BYTEORDER=1234
 # dist/include/mozilla/intl/ICU4CGlue.h:8:10: fatal error: 'unicode/uenum.h' file not found, err: true
 CONFIGURE_ENV+=	BINDGEN_CFLAGS="-I${LOCALBASE}/include"
 
-USES=		tar:xz
+USES=		elfctl tar:xz
 # helpful when testing beta
 WRKSRC=		${WRKDIR}/${PORTNAME}-${DISTVERSION}
+
+ELF_FEATURES=	+noprotmax:dist/bin/firefox \
+		+noprotmax:dist/bin/firefox-bin
 
 FIREFOX_ICON=		${MOZILLA}.png
 FIREFOX_ICON_SRC=	${PREFIX}/lib/${MOZILLA}/browser/chrome/icons/default/default48.png

--- a/www/firefox/files/cheribsd.patch
+++ b/www/firefox/files/cheribsd.patch
@@ -21,3 +21,14 @@
  
    // Try to allocate the region. If the returned address is aligned,
    // either we OOMed (region is nullptr) or we're done.
+--- toolkit/xre/nsAppRunner.cpp.orig
++++ toolkit/xre/nsAppRunner.cpp
+@@ -4514,7 +4514,7 @@
+       return true;
+     }
+   }
+-#  ifdef EARLY_BETA_OR_EARLIER
++#  if 1
+   // Enable by default when we're running on a recent enough GTK version. We'd
+   // like to check further details like compositor version and so on ideally
+   // to make sure we don't enable it on old Mutter or what not, but we can't,


### PR DESCRIPTION
Disable implied PROT_MAX and prefer Wayland.

I've compiled these on amd64 and verified the elf flags took, but not tested the results.