### PR TITLE
Clear build blockers

### DIFF
--- a/Mk/Uses/compiler.mk
+++ b/Mk/Uses/compiler.mk
@@ -181,7 +181,7 @@ _LLVM_MINVER=	11
 .    else
 _LLVM_MINVER=	0
 .    endif
-.    if (defined(FAVORITE_COMPILER) && ${FAVORITE_COMPILER} == gcc) || (${ARCH} != amd64 && ${ARCH} != i386) # clang not always supported on Tier-2
+.    if (defined(FAVORITE_COMPILER) && ${FAVORITE_COMPILER} == gcc)
 USE_GCC=	yes
 CHOSEN_COMPILER_TYPE=	gcc
 .    elif ${COMPILER_TYPE} == gcc || \

--- a/devel/autoconf/Makefile
+++ b/devel/autoconf/Makefile
@@ -3,9 +3,6 @@ PORTVERSION=	2.71
 CATEGORIES=	devel
 MASTER_SITES=	GNU
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
-
 MAINTAINER=	tijl@FreeBSD.org
 COMMENT=	Generate configure scripts and related files
 WWW=		https://www.gnu.org/software/autoconf/

--- a/devel/automake/Makefile
+++ b/devel/automake/Makefile
@@ -3,9 +3,6 @@ PORTVERSION=	1.16.5
 CATEGORIES=	devel
 MASTER_SITES=	GNU
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
-
 MAINTAINER=	tijl@FreeBSD.org
 COMMENT=	GNU Standards-compliant Makefile generator
 WWW=		https://www.gnu.org/software/automake/

--- a/devel/cmake-core/Makefile
+++ b/devel/cmake-core/Makefile
@@ -6,9 +6,6 @@ MASTER_SITES=	https://github.com/Kitware/CMake/releases/download/v${DISTVERSION}
 		https://www.cmake.org/files/v${PORTVERSION}/
 PKGNAMESUFFIX=	-core
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
-
 MAINTAINER=	kde@FreeBSD.org
 COMMENT=	Cross-platform Makefile generator
 WWW=		https://www.cmake.org/
@@ -18,9 +15,9 @@ LICENSE_FILE=	${WRKSRC}/Copyright.txt
 
 LIB_DEPENDS=	libcurl.so:ftp/curl \
 		libexpat.so:textproc/expat2 \
-		libjsoncpp.so:devel/jsoncpp \
 		libuv.so:devel/libuv \
 		librhash.so:security/rhash
+
 
 USES=		compiler:c++11-lang cpe ncurses
 
@@ -45,6 +42,13 @@ CPACK_USES_OFF=		libarchive
 CXXFLAGS+=	-D__BSD_VISIBLE
 
 .include <bsd.port.pre.mk>
+
+# jsoncpp needs meson when built as a package
+.if ${ABI:Mpurecap}
+CONFIGURE_ARGS+=	--no-system-jsoncpp
+.else
+LIB_DEPENDS+=	libjsoncpp.so:devel/jsoncpp
+.endif
 
 .if defined(STRIP) && ${STRIP} != "" && !defined(WITH_DEBUG)
 INSTALL_TARGET=	install/strip

--- a/devel/cmake/Makefile
+++ b/devel/cmake/Makefile
@@ -2,8 +2,6 @@ PORTNAME=	cmake
 DISTVERSION=	3.24.0
 CATEGORIES=	devel
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
 
 MAINTAINER=	kde@FreeBSD.org
 COMMENT=	Meta-port to connect all CMake bits
@@ -18,6 +16,7 @@ PLIST_FILES=	# not applicable
 
 OPTIONS_DEFINE=	DOCS GUI MANPAGES
 OPTIONS_DEFAULT=	MANPAGES
+OPTIONS_EXCLUDE_purecap=	DOCS MANPAGES	# sphinx
 
 GUI_DESC=		Qt-based GUI
 

--- a/devel/ninja/Makefile
+++ b/devel/ninja/Makefile
@@ -4,9 +4,6 @@ DISTVERSIONPREFIX=	v
 PORTEPOCH=	2
 CATEGORIES=	devel
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
-
 MAINTAINER=	kde@FreeBSD.org
 COMMENT=	Small build system closest in spirit to Make
 WWW=		https://ninja-build.org/


### PR DESCRIPTION
Work around issues in some top-10 blockers.

Remove incorrect BROKEN entries, work around breakage in a few other cases.

With these changes meson/python will be our biggest blockers followed by go and openjdk.

(Branch contains commits from #81)