### PR TITLE
Enable GUI stack package building with Poudriere

### DIFF
--- a/Mk/Scripts/do-depends.sh
+++ b/Mk/Scripts/do-depends.sh
@@ -197,7 +197,7 @@ for _line in ${dp_RAWDEPENDS} ; do
 		# this prevent a MITM attack.
 		if [ "${last}" = "fetch" ]; then
 			target=checksum
-		elif [ "${last}" = "usepkg64" ]; then
+		elif [ "${last}" = "pkg64" ]; then
 			usepkg64=1
 		else
 			target=${last}

--- a/Mk/Uses/autoreconf.mk
+++ b/Mk/Uses/autoreconf.mk
@@ -74,7 +74,7 @@ _USES_POST+=	autoreconf
 .if defined(AUTORECONF_CMD)
 AUTORECONF=	${AUTORECONF_CMD}
 .else
-AUTORECONF?=	${LOCALBASE64}/bin/autoreconf${_AUTORECONF}
+AUTORECONF?=	${LOCALBASE}/bin/autoreconf${_AUTORECONF}
 .endif
 AUTORECONF_WRKSRC?=	${WRKSRC}
 
@@ -108,7 +108,7 @@ BUILD_DEPENDS+=	automake>=1.16.5:devel/automake
 .  endif
 
 .  if defined(libtool_ARGS) && empty(libtool_ARGS:Mbuild)
-BUILD_DEPENDS+=	${LOCALBASE64}/bin/libtoolize:devel/libtool:usepkg64
+BUILD_DEPENDS+=	libtoolize:devel/libtool
 .  endif
 
 # In case autoconf-switch wrapper scripts are used during build.

--- a/Mk/Uses/cmake.mk
+++ b/Mk/Uses/cmake.mk
@@ -98,10 +98,6 @@ CMAKE_ARGS+=		-DCMAKE_C_COMPILER:STRING="${CC}" \
 			-DTHREADS_HAVE_PTHREAD_ARG:BOOL=YES \
 			-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=YES \
 			-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
-.  if ${USES:Mcmake} && ${ABI:Mpurecap}
-# CheriABI msgfmt is broken. Use a hybrid ABI version instead globally.
-CMAKE_ARGS+=		-DGETTEXT_MSGFMT_EXECUTABLE=${LOCALBASE64}/bin/msgfmt
-.  endif
 
 # Handle the option-like CMAKE_ON and CMAKE_OFF lists.
 .  for _bool_kind in ON OFF

--- a/Mk/Uses/meson.mk
+++ b/Mk/Uses/meson.mk
@@ -27,7 +27,7 @@ IGNORE=	Incorrect 'USES+= meson:${meson_ARGS}'. meson takes no arguments
 .  if defined(MESON_CMD)
 BUILD_DEPENDS+=		${MESON_CMD}:/nonexistent
 .  else
-BUILD_DEPENDS+=		meson>=0.57.1_1:devel/meson
+BUILD_DEPENDS+=		${LOCALBASE64}/bin/meson:devel/meson
 .  endif
 
 # meson uses ninja

--- a/Mk/Uses/perl5.mk
+++ b/Mk/Uses/perl5.mk
@@ -154,6 +154,7 @@ IGNORE=	improper use of USE_PERL5
 
 _USE_PERL5_VALID=	build configure extract modbuild modbuildtiny patch run \
 			test
+_USE_PERL5_VALID+=	pkg64
 _USE_PERL5_UNKNOWN=
 .  for component in ${_USE_PERL5}
 .    if empty(_USE_PERL5_VALID:M${component})
@@ -227,16 +228,23 @@ CONFIGURE_ENV+=	PERL_MM_USE_DEFAULT="YES"
 .    endif # defined(BATCH) && !defined(IS_INTERACTIVE)
 .  endif # configure
 
+.  if ${_USE_PERL5:Mpkg64}
+PERL5_DEPEND=		${LOCALBASE64}/bin/perl${PERL_VERSION}
+PERL5_PKG64=		:pkg64
+.  else
+PERL5_PKG64=
+.  endif
+
 .  if ${_USE_PERL5:Mextract}
-EXTRACT_DEPENDS+=	${PERL5_DEPEND}:lang/${PERL_PORT}
+EXTRACT_DEPENDS+=	${PERL5_DEPEND}:lang/${PERL_PORT}${PERL5_PKG64}
 .  endif
 
 .  if ${_USE_PERL5:Mpatch}
-PATCH_DEPENDS+=		${PERL5_DEPEND}:lang/${PERL_PORT}
+PATCH_DEPENDS+=		${PERL5_DEPEND}:lang/${PERL_PORT}${PERL5_PKG64}
 .  endif
 
 .  if ${_USE_PERL5:Mbuild}
-BUILD_DEPENDS+=		${PERL5_DEPEND}:lang/${PERL_PORT}
+BUILD_DEPENDS+=		${PERL5_DEPEND}:lang/${PERL_PORT}${PERL5_PKG64}
 .  endif
 
 .  if ${_USE_PERL5:Mrun}

--- a/Mk/Uses/python.mk
+++ b/Mk/Uses/python.mk
@@ -308,7 +308,7 @@ IGNORE=		uses either USE_PYTHON=pytest or USE_PYTHON=pytest4, not both of them
 # Currently, only hybrid ABI Python is available on CheriBSD.
 # A port dependency that is installed in the Python site-packages tree can be
 # installed with the hybrid ABI Python.
-BROKEN_purecap=	requires missing CheriABI Python
+BROKEN_purecap=	Requires Python that does not build for CheriABI
 USE_PKG64=	1
 .  endif
 

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -2868,6 +2868,9 @@ IGNORE=		is marked as broken on ${ARCH}: ${BROKEN_${ARCH}}
 .          if defined(BROKEN_${_abi})
 .            if !defined(TRYBROKEN)
 IGNORE=		is marked as broken for ${_abi}: ${BROKEN_${_abi}}
+.              if ${_abi} == "purecap" && ${USE_PKG64} == 1
+IGNORE:=	${IGNORE}. Consider installing this port with pkg64
+.              endif
 .            endif
 .          endif
 .        endfor

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -4092,7 +4092,7 @@ ${deptype:tl}-depends:
 # Dependency lists: both build and runtime, recursive.  Print out directory names.
 
 _UNIFIED_DEPENDS=${PKG_DEPENDS} ${EXTRACT_DEPENDS} ${PATCH_DEPENDS} ${FETCH_DEPENDS} ${BUILD_DEPENDS} ${LIB_DEPENDS} ${RUN_DEPENDS} ${TEST_DEPENDS}
-_DEPEND_SPECIALS=	${_UNIFIED_DEPENDS:M*\:*\:*:C,^[^:]*:([^:]*):.*$,\1,}
+_DEPEND_SPECIALS=	${_UNIFIED_DEPENDS:N*\:pkg64:M*\:*\:*:C,^[^:]*:([^:]*):.*$,\1,}
 
 .    for d in ${_UNIFIED_DEPENDS:M*\:/*}
 _PORTSDIR_STR=	$${PORTSDIR}/

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -3262,6 +3262,13 @@ run-cheri-gnulib-fixup:
 			echo "#include_next <stdint.h>" > $${f} ; \
 		fi \
 	done
+# Patch rawmemchr not to use uintptr_t to store arbitrary bytes.
+	-@for f in `${FIND} ${WRKDIR} -type f -name rawmemchr.c` ; do \
+		if grep -q "typedef uintptr_t longword" $${f} ; then \
+			echo "Replacing $${f}" ; \
+			${PATCH} -s $${f} ${PORTSDIR}/devel/gnulib/files/extrapatch-cheribsd-rawmemchr.patch ; \
+		fi \
+	done
 .    endif
 
 .    if !target(run-autotools-fixup)

--- a/devel/gnulib/files/extrapatch-cheribsd-rawmemchr.patch
+++ b/devel/gnulib/files/extrapatch-cheribsd-rawmemchr.patch
@@ -1,0 +1,21 @@
+--- rawmemchr.c.orig	2022-01-04 08:33:30.000000000 +0000
++++ rawmemchr.c	2023-04-03 10:33:33.761858000 +0000
+@@ -32,11 +32,13 @@
+ void *
+ rawmemchr (const void *s, int c_in)
+ {
+-  /* Change this typedef to experiment with performance.  */
+-  typedef uintptr_t longword;
+-  /* If you change the "uintptr_t", you should change UINTPTR_WIDTH to match.
+-     This verifies that the type does not have padding bits.  */
+-  verify (UINTPTR_WIDTH == UCHAR_WIDTH * sizeof (longword));
++  /* Change this *_WIDTH macro and typedef to experiment
++     with performance.  */
++# define LONGWORD_WIDTH ULONG_WIDTH
++  typedef unsigned long int longword;
++  /* This verifies that the type does not have padding bits.  */
++  verify (LONGWORD_WIDTH == UCHAR_WIDTH * sizeof (longword));
++# undef LONGWORD_WIDTH
+ 
+   const unsigned char *char_ptr;
+   unsigned char c = c_in;

--- a/devel/kf5-ki18n/Makefile
+++ b/devel/kf5-ki18n/Makefile
@@ -6,7 +6,7 @@ MAINTAINER=	kde@FreeBSD.org
 COMMENT=	KF5 advanced internationalization framework
 
 USES=		cmake compiler:c++11-lib gettext-runtime \
-		gettext-tools:build,run kde:5 qt:5 tar:xz
+		gettext-tools:build,run kde:5 python:3.6+ qt:5 tar:xz
 USE_KDE=	ecm:build
 USE_QT=		concurrent core declarative network \
 		buildtools:build qmake:build testlib:build

--- a/devel/meson/Makefile
+++ b/devel/meson/Makefile
@@ -3,9 +3,6 @@ PORTVERSION=	0.63.2
 CATEGORIES=	devel python
 MASTER_SITES=	https://github.com/mesonbuild/${PORTNAME}/releases/download/${PORTVERSION}/
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
-
 MAINTAINER=	desktop@FreeBSD.org
 COMMENT=	High performance build system
 WWW=		https://mesonbuild.com/

--- a/devel/py-lxml/Makefile
+++ b/devel/py-lxml/Makefile
@@ -9,9 +9,6 @@ COMMENT=	Pythonic binding for the libxml2 and libxslt libraries
 WWW=		https://lxml.de/ \
 		https://github.com/lxml/lxml
 
-BROKEN_purecap=	requires missing CheriABI Python
-USE_PKG64=	1
-
 LICENSE=	BSD3CLAUSE
 LICENSE_FILE=	${WRKSRC}/doc/licenses/BSD.txt
 

--- a/devel/qt5-qmake/Makefile
+++ b/devel/qt5-qmake/Makefile
@@ -14,7 +14,7 @@ SHEBANG_FILES=	util/harfbuzz/update-harfbuzz \
 		mkspecs/features/data/mac/objc_namespace.sh \
 		mkspecs/features/uikit/devices.py \
 		mkspecs/features/uikit/device_destinations.sh
-USE_PERL5=	extract
+USE_PERL5=	extract pkg64
 
 REINPLACE_ARGS=	-i ""
 HAS_CONFIGURE=	yes

--- a/devel/yaml-cpp/Makefile
+++ b/devel/yaml-cpp/Makefile
@@ -23,4 +23,14 @@ post-patch:
 	@${REINPLACE_CMD} "s|%%PREFIX%%|${PREFIX}|" \
 		${WRKSRC}/yaml-cpp-config.cmake.in
 
-.include <bsd.port.mk>
+.include <bsd.port.pre.mk>
+
+.if ${CMAKE_BUILD_TYPE} == "Debug"
+# yaml-cpp sets CMAKE_DEBUG_POSTFIX="d" that results in the "d" suffix added to
+# shared library file names.
+PLIST_SUB+=	CMAKE_DEBUG_POSTFIX="d"
+.else
+PLIST_SUB+=	CMAKE_DEBUG_POSTFIX=""
+.endif
+
+.include <bsd.port.post.mk>

--- a/devel/yaml-cpp/pkg-plist
+++ b/devel/yaml-cpp/pkg-plist
@@ -39,7 +39,7 @@ lib/cmake/yaml-cpp/yaml-cpp-config-version.cmake
 lib/cmake/yaml-cpp/yaml-cpp-config.cmake
 lib/cmake/yaml-cpp/yaml-cpp-targets-%%CMAKE_BUILD_TYPE%%.cmake
 lib/cmake/yaml-cpp/yaml-cpp-targets.cmake
-lib/libyaml-cpp.so
-lib/libyaml-cpp.so.0
-lib/libyaml-cpp.so.0.7.0
+lib/libyaml-cpp%%CMAKE_DEBUG_POSTFIX%%.so
+lib/libyaml-cpp%%CMAKE_DEBUG_POSTFIX%%.so.0
+lib/libyaml-cpp%%CMAKE_DEBUG_POSTFIX%%.so.0.7.0
 libdata/pkgconfig/yaml-cpp.pc

--- a/lang/python39/Makefile
+++ b/lang/python39/Makefile
@@ -6,7 +6,7 @@ PKGNAMESUFFIX=	${PYTHON_SUFFIX}
 DISTNAME=	Python-${DISTVERSION}
 DIST_SUBDIR=	python
 
-BROKEN_purecap=	does not build for CheriABI
+BROKEN_purecap=	Does not build for CheriABI
 USE_PKG64=	1
 
 MAINTAINER=	python@FreeBSD.org

--- a/textproc/kf5-syntax-highlighting/Makefile
+++ b/textproc/kf5-syntax-highlighting/Makefile
@@ -7,6 +7,8 @@ COMMENT=	KF5 syntax highlighting engine for structured text and code
 
 USES=		cmake compiler:c++11-lib kde:5 perl5 qt:5 tar:xz
 USE_KDE=	ecm:build
+# Use hybrid ABI Perl
+USE_PERL5=	run build pkg64
 USE_QT=		core gui network \
 		buildtools:build linguisttools:build testlib:build qmake:build
 

--- a/x11-themes/kf5-breeze-icons/Makefile
+++ b/x11-themes/kf5-breeze-icons/Makefile
@@ -24,6 +24,8 @@ CMAKE_ON=	WITH_ICON_GENERATION
 .include <bsd.port.options.mk>
 
 CMAKE_BUILD_TYPE=Release
-BUILD_DEPENDS+=	${PYTHON_PKGNAMEPREFIX}lxml>=0:devel/py-lxml@${PY_FLAVOR}
+# Depend on lxml from PYTHON_SITELIBDIR to allow to use a pre-installed hybrid
+# ABI version.
+BUILD_DEPENDS+=	${PYTHON_SITELIBDIR}/lxml:devel/py-lxml@${PY_FLAVOR}
 
 .include <bsd.port.mk>


### PR DESCRIPTION
These changes fix remaining issues to enable GUI stack package building with Poudriere, making use of hybrid ABI utilities. With https://github.com/CTSRD-CHERI/poudriere/pull/1 and this PR, we should be able to build all CherIBSD packages using our Poudriere infrastructure.