### PR TITLE
Switch to new Morello ABI

### DIFF
--- a/devel/llvm-base/files/wrapper.sh.in
+++ b/devel/llvm-base/files/wrapper.sh.in
@@ -110,9 +110,12 @@ aarch64c)
 	if [ "$CHERIBSD_VERSION" -le 20220314 ]; then
 		tls_flags="-femulated-tls"
 		vararg_flags=
-	else
+	elif [ "$CHERIBSD_VERSION" -le 20220828 ]
 		tls_flags=
 		vararg_flags="-Xclang -morello-vararg=new"
+	else
+		tls_flags=
+		vararg_flags="-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs=caller-only"	
 	fi
 
 	arch_cflags="-march=morello -mabi=purecap $tls_flags $vararg_flags"


### PR DESCRIPTION
Enable `-morello-bounded-memargs=caller-only` for all new purecap builds. See also CTSRD-CHERI/cheribsd#1695.