### PR TITLE
math/gmp: Support purecap builds on Morello.

### DIFF
--- a/math/gmp/Makefile
+++ b/math/gmp/Makefile
@@ -50,6 +50,10 @@ CONFIGURE_ENV+=	ABI="64"
 CONFIGURE_ENV+=	ABI="32"
 .endif
 
+.if ${ABI:Mpurecap}
+CONFIGURE_ARGS+=--disable-assembly
+.endif
+
 post-extract:
 	@${RM} ${WRKSRC}/doc/gmp.info*
 

--- a/math/gmp/files/cheribsd.patch
+++ b/math/gmp/files/cheribsd.patch
@@ -1,0 +1,26 @@
+--- configure.orig	2020-11-14 18:45:15 UTC
++++ configure
+@@ -4260,8 +4260,8 @@ echo "include_mpn(\`alpha/default.m4')" >> $gmp_tmpcon
+     CALLING_CONVENTIONS_OBJS='arm32call.lo arm32check.lo'
+     CALLING_CONVENTIONS_OBJS_64=""
+     cclist_64="gcc cc"
+-    any_32_testlist="sizeof-void*-4"
+-    any_64_testlist="sizeof-void*-8"
++    any_32_testlist="sizeof-long-4"
++    any_64_testlist="sizeof-long-8"
+ 
+     # This is needed for clang, which is not content with flags like -mfpu=neon
+     # alone.
+--- configure.ac.orig	2020-11-14 18:45:09 UTC
++++ configure.ac
+@@ -622,8 +622,8 @@ case $host in
+     CALLING_CONVENTIONS_OBJS='arm32call.lo arm32check.lo'
+     CALLING_CONVENTIONS_OBJS_64=""
+     cclist_64="gcc cc"
+-    any_32_testlist="sizeof-void*-4"
+-    any_64_testlist="sizeof-void*-8"
++    any_32_testlist="sizeof-long-4"
++    any_64_testlist="sizeof-long-8"
+ 
+     # This is needed for clang, which is not content with flags like -mfpu=neon
+     # alone.


### PR DESCRIPTION
- Patch configure to use sizeof(long) instead of sizeof(void *) to decide on 32 vs 64-bit ABI for aarch64.

- Disable assembly for purecap ABIs.