### PR TITLE
Fix emacs hybrid ABI builds.

### DIFF
--- a/editors/emacs/files/patch-cheribsd-stdint.patch
+++ b/editors/emacs/files/patch-cheribsd-stdint.patch
@@ -1,0 +1,68 @@
+diff --git src/bignum.c src/bignum.c
+index 6c6c369ddd8..ea378eed3ba 100644
+--- src/bignum.c
++++ src/bignum.c
+@@ -26,6 +26,13 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ #include <math.h>
+ #include <stdlib.h>
+
++#ifndef INTMAX_WIDTH
++#define INTMAX_WIDTH _GL_INTEGER_WIDTH (INTMAX_MIN, INTMAX_MAX)
++#endif
++#ifndef UINTMAX_WIDTH
++#define UINTMAX_WIDTH _GL_INTEGER_WIDTH (0, UINTMAX_MAX)
++#endif
++
+ /* mpz global temporaries.  Making them global saves the trouble of
+    properly using mpz_init and mpz_clear on temporaries even when
+    storage is exhausted.  Admittedly this is not ideal.  An mpz value
+diff --git src/lisp.h src/lisp.h
+index 0cad97c0774..b42f0a34e72 100644
+--- src/lisp.h
++++ src/lisp.h
+@@ -119,6 +119,11 @@ enum {  BOOL_VECTOR_BITS_PER_CHAR =
+         BOOL_VECTOR_BITS_PER_CHAR
+ };
+
++#ifndef SIZE_WIDTH
++# define __SIZE_WIDTH _GL_INTEGER_WIDTH(0, SIZE_T_MAX)
++# define SIZE_WIDTH __SIZE_WIDTH
++#endif
++
+ /* An unsigned integer type representing a fixed-length bit sequence,
+    suitable for bool vector words, GC mark bits, etc.  Normally it is size_t
+    for speed, but on weird platforms it is unsigned char and not all
+@@ -134,6 +139,11 @@ enum { BITS_PER_BITS_WORD = BOOL_VECTOR_BITS_PER_CHAR };
+ #endif
+ verify (BITS_WORD_MAX >> (BITS_PER_BITS_WORD - 1) == 1);
+
++#ifdef __SIZE_WIDTH
++# undef SIZE_WIDTH
++# undef __SIZE_WIDTH
++#endif
++
+ /* Use pD to format ptrdiff_t values, which suffice for indexes into
+    buffers and strings.  Emacs never allocates objects larger than
+    PTRDIFF_MAX bytes, as they cause problems with pointer subtraction.
+diff --git src/xterm.c src/xterm.c
+index 9a8c3e9ad76..8b6109a3f25 100644
+--- src/xterm.c
++++ src/xterm.c
+@@ -5633,8 +5633,17 @@ x_send_scroll_bar_event (Lisp_Object window, enum scroll_bar_part part,
+   struct window *w = XWINDOW (window);
+   struct frame *f = XFRAME (w->frame);
+   intptr_t iw = (intptr_t) w;
++
++#ifndef INTPTR_WIDTH
++#define __INTPTR_WIDTH _GL_INTEGER_WIDTH (INTPTR_MIN, INTPTR_MAX)
++#define INTPTR_WIDTH __INTPTR_WIDTH
++#endif
+   verify (INTPTR_WIDTH <= 64);
+   int sign_shift = INTPTR_WIDTH - 32;
++#ifdef __INTPTR_WIDTH
++#undef INTPTR_WIDTH
++#undef __INTPTR_WIDTH
++#endif
+
+   block_input ();
+


### PR DESCRIPTION
Add extra definitions to work around the absence of INTMAX_WIDTH, UINTMAX_WIDTH and SIZE_WIDTH from CheriBSD stdint.h

This should resolve #126 