### PR TITLE
devel/llvm-base: depend on the absolute clang path

### DIFF
--- a/devel/llvm-base/Makefile
+++ b/devel/llvm-base/Makefile
@@ -14,7 +14,7 @@ LICENSE_FILE=	${FILESDIR}/LICENSE.ETC
 FLAVORS=	base localbase
 FLAVOR?=	${FLAVORS:[1]}
 
-RUN_DEPENDS=	clang:devel/llvm
+RUN_DEPENDS=	${LOCALBASE}/bin/clang:devel/llvm
 
 .if ${FLAVOR:Mlocalbase}
 CONFLICTS_INSTALL=	binutils


### PR DESCRIPTION
Mk/Scripts/actual-package-depends.sh removes a dependency on clang if it is found in $PATH and does not belong to any package.

Since FreeBSD does include clang in the base system and hence it would find it in $PATH as well, change the dependency on clang to use its absolute path rather than a binary name.