### PR TITLE
textproc/jade: remove non-functional deoptimization

### DIFF
--- a/textproc/jade/Makefile
+++ b/textproc/jade/Makefile
@@ -42,9 +42,4 @@ post-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/share/xml/jade
 	${INSTALL_DATA} ${WRKSRC}/pubtext/xml* ${STAGEDIR}${PREFIX}/share/xml/jade
 
-.include <bsd.port.pre.mk>
-
-# Same problem with textproc/openjade.
-CPPFLAGS:=	-O ${CFLAGS:N-O*:N-m*}
-
-.include <bsd.port.post.mk>
+.include <bsd.port.mk>


### PR DESCRIPTION
This fixes configure and build on CheriBSD