### PR TITLE
Disable unadapted legacy assembly in a few ports

### DIFF
--- a/audio/mpg123/Makefile.purecap
+++ b/audio/mpg123/Makefile.purecap
@@ -1,1 +1,2 @@
-BROKEN_purecap_failed=1
+# disable assembly since it's no adapted to CHERI
+CONFIGURE_ARGS+=--with-cpu=generic_fpu

--- a/security/gnutls/Makefile.purecap
+++ b/security/gnutls/Makefile.purecap
@@ -1,0 +1,1 @@
+CONFIGURE_ARGS+=--disable-hardware-acceleration

--- a/security/nettle/Makefile.purecap
+++ b/security/nettle/Makefile.purecap
@@ -1,1 +1,1 @@
-BROKEN_purecap_failed=1
+CONFIGURE_ARGS+=	--disable-assembler


### PR DESCRIPTION
Get some top blockers working by disabling their assembly bits that don't work with purecap.