### PR TITLE
c18n: Enable -morello-bounded-memargs for purecap userland

### DIFF
--- a/devel/llvm-base/Makefile
+++ b/devel/llvm-base/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	llvm
-PORTVERSION=	5
+PORTVERSION=	20240315
 CATEGORIES=	devel lang
 MASTER_SITES=	# not applicable
 DISTFILES=	# not applicable

--- a/devel/llvm-base/files/wrapper.sh.in
+++ b/devel/llvm-base/files/wrapper.sh.in
@@ -113,9 +113,12 @@ aarch64c)
 	elif [ "$CHERIBSD_VERSION" -le 20220828 ]; then
 		tls_flags=
 		vararg_flags="-Xclang -morello-vararg=new"
-	else
+	elif [ "$CHERIBSD_VERSION" -le 20230804 ]; then
 		tls_flags=
 		vararg_flags="-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs=caller-only"
+	else
+		tls_flags=
+		vararg_flags="-Xclang -morello-vararg=new -Xclang -morello-bounded-memargs"
 	fi
 
 	arch_cflags="-march=morello -mabi=purecap $tls_flags $vararg_flags"


### PR DESCRIPTION
The `cc` script will use this flag by default starting with the next CheriBSD release.