### PR TITLE
devel/ghidra-meta: add meta port and ignore devel/ghidra

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -810,6 +810,7 @@
     SUBDIR += gh
     SUBDIR += ghidra
     SUBDIR += ghidra-cheri
+    SUBDIR += ghidra-meta
     SUBDIR += ghostie
     SUBDIR += ghq
     SUBDIR += ghub

--- a/devel/ghidra-meta/Makefile
+++ b/devel/ghidra-meta/Makefile
@@ -1,0 +1,16 @@
+PORTNAME=	ghidra
+PORTVERSION=	${GHIDRA_VERSION}
+PORTREVISION=	0
+CATEGORIES=	devel
+
+MAINTAINER=	zyj20@cl.cam.ac.uk
+COMMENT=	Meta-port for the default version of the Ghidra SRE framework
+WWW=		https://ghidra-sre.org/
+DESCR=		${.CURDIR}/../ghidra/pkg-descr
+
+USES=		metaport
+
+RUN_DEPENDS=	${LOCALBASE}/bin/ghidra-cheri:devel/ghidra-cheri
+
+.include "${.CURDIR}/../ghidra-cheri/Makefile.snapshot"
+.include <bsd.port.mk>

--- a/devel/ghidra/Makefile
+++ b/devel/ghidra/Makefile
@@ -1,3 +1,5 @@
+IGNORE=		is replaced by devel/ghidra-meta on CheriBSD
+
 PORTNAME=	ghidra
 DISTVERSIONPREFIX=	Ghidra_
 DISTVERSION=	9.1


### PR DESCRIPTION
A user trying to explicitly build devel/ghidra will be informed that it's ignored on CheriBSD, similar to https://github.com/CTSRD-CHERI/cheribsd-ports/commit/28e64816f4b4be9b8dd11cedebe5fd517d0d0394. 