### PR TITLE
devel/llvm-base: switch to init-all=zero

### DIFF
--- a/devel/llvm-base/Makefile
+++ b/devel/llvm-base/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	llvm
-PORTVERSION=	5
+PORTVERSION=	6
 CATEGORIES=	devel lang
 MASTER_SITES=	# not applicable
 DISTFILES=	# not applicable

--- a/devel/llvm-base/files/wrapper.sh.in
+++ b/devel/llvm-base/files/wrapper.sh.in
@@ -91,6 +91,11 @@ esac
 # version in ${LOCALBASE}/bin to ensure LD_LIBRARY_PATH is correct.
 realtool=${LOCALBASE}/bin/${llvmtool}
 
+cflags=
+if [ "$CHERIBSD_VERSION" -gt 20230804 ]; then
+	cflags="-ftrivial-auto-var-init=zero"
+fi
+
 # CheriBSD: assume that if we're on a CHERI architecture we want either
 # purecap or hybrid binaries.
 arch_cflags=
@@ -131,7 +136,7 @@ esac
 
 case $tool in
 cc|c++|cpp)
-	toolflags=$arch_cflags
+	toolflags=$cflags $arch_cflags
 	;;
 ld|ld.lld)
 	# no flags should be required as ld can see what it's doing from


### PR DESCRIPTION
Zero bits of the stack the compiler can't prove are initialized before use or escape by default.

Issue: https://github.com/CTSRD-CHERI/cheribsd/issues/2045
See also: https://github.com/CTSRD-CHERI/cheribsd/pull/2046