### PR TITLE
llvm-base: add clang{,++,-cpp} wrappers

### DIFF
--- a/devel/llvm-base/Makefile
+++ b/devel/llvm-base/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	llvm
-PORTVERSION=	20240315
+PORTVERSION=	20240426
 CATEGORIES=	devel lang
 MASTER_SITES=	# not applicable
 DISTFILES=	# not applicable
@@ -28,7 +28,7 @@ NO_ARCH=	yes
 
 SUB_FILES=	wrapper.sh
 
-COMMANDS=	cc c++ cpp ld objdump
+COMMANDS=	cc clang c++ clang++ cpp clang-cpp ld objdump
 .if ${FLAVOR:Mbase}
 # Conflicts with devel/llvm in localbase flavor
 COMMANDS+=	ld.lld

--- a/devel/llvm-base/files/wrapper.sh.in
+++ b/devel/llvm-base/files/wrapper.sh.in
@@ -68,13 +68,13 @@ tool=$0
 tool=${tool##*/}
 
 case $tool in
-cc)
+cc|clang)
 	llvmtool=clang
 	;;
-c++)
+c++|clang++)
 	llvmtool=clang++
 	;;
-cpp)
+cpp|clang-cpp)
 	llvmtool=clang-cpp
 	;;
 ld|ld.lld)
@@ -133,7 +133,7 @@ riscv64c)
 esac
 
 case $tool in
-cc|c++|cpp)
+cc|clang|c++|clang++|cpp|clang-cpp)
 	toolflags=$arch_cflags
 	;;
 ld|ld.lld)


### PR DESCRIPTION
Add missing clang{,++,-cpp} wrappers that can be found in the FreeBSD base system.

Discussed with:	@eupharina