### PR TITLE
devel/distcc: Add a -pump flavor.

### DIFF
--- a/devel/distcc/Makefile
+++ b/devel/distcc/Makefile
@@ -10,6 +10,10 @@ WWW=		https://distcc.github.io/
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+FLAVORS=	default pump
+FLAVOR?=	${FLAVORS:[1]}
+pump_PKGNAMESUFFIX=	-pump
+
 BUILD_DEPENDS=	${LOCALBASE}/lib/libiberty.a:devel/gnulibiberty
 LIB_DEPENDS=	libpopt.so:devel/popt
 
@@ -41,6 +45,10 @@ PLIST_FILES=	${_BIN_FILES:S|^|bin/|} \
 		etc/default/distcc
 
 OPTIONS_DEFINE=		AVAHI CLANGLINK DOCS IPV6 LLVMLINK PUMP GUI
+
+.if ${FLAVOR:U} == pump
+OPTIONS_DEFAULT+=	PUMP
+.endif
 
 CLANGLINK_DESC=	Create clang compiler links if clang is installed
 GUI_DESC=	Build GUI distcc monitor


### PR DESCRIPTION
By default, distcc does not support preprocessing of headers on remote machines. This can cause bottlenecks when compiling C++ code that makes heavy use of headers for optimization and headers like v8. Add a flavor to distcc that compiles it in pump mode, which allows distcc to offload header processing to remote machines.