### PR TITLE
lang/go: Add Go 1.21 port from upstream and bump default version

### DIFF
--- a/Mk/bsd.default-versions.mk
+++ b/Mk/bsd.default-versions.mk
@@ -58,7 +58,7 @@ GHOSTSCRIPT_DEFAULT?=	agpl
 # Possible values: mesa-libs, mesa-devel
 GL_DEFAULT?=		mesa-libs
 # Possible values: 1.18, 1.19, 1.20, 1.21-devel
-GO_DEFAULT?=		1.20
+GO_DEFAULT?=		1.21
 # Possible values: 1.8, 2.2, 3.0
 GUILE_DEFAULT?=		2.2
 # Possible versions: 6, 7

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -124,6 +124,7 @@
     SUBDIR += go118
     SUBDIR += go119
     SUBDIR += go120
+    SUBDIR += go121
     SUBDIR += gomacro
     SUBDIR += gprolog
     SUBDIR += gravity

--- a/lang/go121/Makefile
+++ b/lang/go121/Makefile
@@ -1,0 +1,20 @@
+DISTVERSION=	1.21.0
+# Always set PORTREVISION explicitly as otherwise they are inherited from lang/go-devel
+PORTREVISION=	0
+MASTER_SITES=	https://golang.org/dl/ \
+		https://github.com/dmgk/go-bootstrap/releases/download/${BOOTSTRAP_TAG}/:bootstrap \
+		LOCAL/dmgk:bootstrap
+DISTFILES=	go${DISTVERSION}.src.tar.gz \
+		go-${OPSYS:tl}-${GOARCH_${ARCH}}${GOARM_${ARCH}}-${BOOTSTRAP_TAG}.tar.xz:bootstrap
+
+# Avoid conflicting patch files
+PATCHFILES=
+
+COMMENT=	Go programming language
+
+MASTERDIR=	${.CURDIR}/../go-devel
+PATCHDIR=	${.CURDIR}/files
+WRKSRC=		${WRKDIR}/go
+DISTINFO_FILE=	${.CURDIR}/distinfo
+
+.include "${MASTERDIR}/Makefile"

--- a/lang/go121/distinfo
+++ b/lang/go121/distinfo
@@ -1,0 +1,15 @@
+TIMESTAMP = 1691752848
+SHA256 (go1.21.0.src.tar.gz) = 818d46ede85682dd551ad378ef37a4d247006f12ec59b5b755601d2ce114369a
+SIZE (go1.21.0.src.tar.gz) = 26942359
+SHA256 (go-freebsd-arm64-go1.20.tar.xz) = 674e0a9bce8b64dcc085b000eb83ae880e96be1ee47dad6ec86c82dbe5550623
+SIZE (go-freebsd-arm64-go1.20.tar.xz) = 32640640
+SHA256 (go-freebsd-amd64-go1.20.tar.xz) = 170f612c4b8a59400f27d642aab37afa831fe2d6df3e7473dec2d4574a59a46c
+SIZE (go-freebsd-amd64-go1.20.tar.xz) = 34684360
+SHA256 (go-freebsd-arm6-go1.20.tar.xz) = acf99dbb285c6d2b80e0abfe4bffd0d230516ea84d17be0d5bc1045809e3d33a
+SIZE (go-freebsd-arm6-go1.20.tar.xz) = 33418476
+SHA256 (go-freebsd-arm7-go1.20.tar.xz) = 12dd61c802eada70380f0b4755656d82dbf228575c056775c682456380be5039
+SIZE (go-freebsd-arm7-go1.20.tar.xz) = 33346596
+SHA256 (go-freebsd-386-go1.20.tar.xz) = 34e888a37153270b33503a23885ea4c85ba4bd09849d2c937fc9d312c0f49983
+SIZE (go-freebsd-386-go1.20.tar.xz) = 35448892
+SHA256 (go-freebsd-riscv64-go1.20.tar.xz) = 010921013d24124ff31f4b1965456349547acf936572fc6e0bcf95a0542794bd
+SIZE (go-freebsd-riscv64-go1.20.tar.xz) = 33807544

--- a/lang/go121/files/cheribsd.patch
+++ b/lang/go121/files/cheribsd.patch
@@ -1,0 +1,116 @@
+diff --git src/runtime/defs_freebsd.go src/runtime/defs_freebsd.go
+index d86ae9133a..1a133b4402 100644
+--- src/runtime/defs_freebsd.go
++++ src/runtime/defs_freebsd.go
+@@ -34,6 +34,10 @@ package runtime
+ #include <sys/cpuset.h>
+ #include <sys/param.h>
+ #include <sys/vdso.h>
++
++#ifndef _MC_CAP_VALID
++#define _MC_CAP_VALID 0
++#endif
+ */
+ import "C"
+ 
+@@ -142,6 +146,9 @@ const (
+ 	EV_EOF       = C.EV_EOF
+ 	EVFILT_READ  = C.EVFILT_READ
+ 	EVFILT_WRITE = C.EVFILT_WRITE
++
++	// This is specific to the CheriBSD freebsd64 compat layer
++	MC_CAP_VALID = C._MC_CAP_VALID
+ )
+ 
+ type Rtprio C.struct_rtprio
+diff --git src/runtime/defs_freebsd_arm64.go src/runtime/defs_freebsd_arm64.go
+index 1d6723621a..d3e7940320 100644
+--- src/runtime/defs_freebsd_arm64.go
++++ src/runtime/defs_freebsd_arm64.go
+@@ -110,6 +110,9 @@ const (
+ 	_EV_EOF       = 0x8000
+ 	_EVFILT_READ  = -0x1
+ 	_EVFILT_WRITE = -0x2
++
++	// This is specific to the CheriBSD freebsd64 compat layer
++        _MC_CAP_VALID      = 0x80000000
+ )
+ 
+ type rtprio struct {
+diff --git src/runtime/signal_arm64.go src/runtime/signal_arm64.go
+index c8b87817b4..1af2d6d675 100644
+--- src/runtime/signal_arm64.go
++++ src/runtime/signal_arm64.go
+@@ -65,6 +65,7 @@ func (c *sigctxt) preparePanic(sig uint32, gp *g) {
+ 	// functions are correctly handled. This smashes
+ 	// the stack frame but we're not going back there
+ 	// anyway.
++	c.prepare_mcontext()
+ 	sp := c.sp() - sys.StackAlign // needs only sizeof uint64, but must align the stack
+ 	c.set_sp(sp)
+ 	*(*uint64)(unsafe.Pointer(uintptr(sp))) = c.lr()
+@@ -86,6 +87,7 @@ func (c *sigctxt) pushCall(targetPC, resumePC uintptr) {
+ 	// push the call. The function being pushed is responsible
+ 	// for restoring the LR and setting the SP back.
+ 	// This extra space is known to gentraceback.
++	c.prepare_mcontext()
+ 	sp := c.sp() - 16 // SP needs 16-byte alignment
+ 	c.set_sp(sp)
+ 	*(*uint64)(unsafe.Pointer(uintptr(sp))) = c.lr()
+diff --git src/runtime/signal_darwin_arm64.go src/runtime/signal_darwin_arm64.go
+index 690ffe4ae2..9ca3a63463 100644
+--- src/runtime/signal_darwin_arm64.go
++++ src/runtime/signal_darwin_arm64.go
+@@ -88,3 +88,5 @@ func (c *sigctxt) fixsigcode(sig uint32) {
+ 		}
+ 	}
+ }
++
++func (c *sigctxt) prepare_mcontext() {}
+diff --git src/runtime/signal_freebsd_arm64.go src/runtime/signal_freebsd_arm64.go
+index 159e965a7d..2739d06a99 100644
+--- src/runtime/signal_freebsd_arm64.go
++++ src/runtime/signal_freebsd_arm64.go
+@@ -64,3 +64,12 @@ func (c *sigctxt) set_r28(x uint64) { c.regs().mc_gpregs.gp_x[28] = x }
+ 
+ func (c *sigctxt) set_sigcode(x uint64) { c.info.si_code = int32(x) }
+ func (c *sigctxt) set_sigaddr(x uint64) { c.info.si_addr = x }
++
++func (c *sigctxt) prepare_mcontext() {
++	// Clear the _MC_CAP_VALID flag so that mcontext updates the registers
++	// upon sigreturn. Any capabilities will be invalidated on freebsd64,
++	// but this is fine, we are not an hybrid program.
++	// This is not done in libpthread because it does not directly modify
++	// registers in the context.
++	c.regs().mc_flags &= (int32)(^uint32(_MC_CAP_VALID))
++}
+diff --git src/runtime/signal_linux_amd64.go src/runtime/signal_linux_amd64.go
+index 573b118397..eb66c55495 100644
+--- src/runtime/signal_linux_amd64.go
++++ src/runtime/signal_linux_amd64.go
+@@ -54,3 +54,5 @@ func (c *sigctxt) set_sigcode(x uint64) { c.info.si_code = int32(x) }
+ func (c *sigctxt) set_sigaddr(x uint64) {
+ 	*(*uintptr)(add(unsafe.Pointer(c.info), 2*goarch.PtrSize)) = uintptr(x)
+ }
++
++func (c *sigctxt) prepare_mcontext() {}
+diff --git src/runtime/signal_netbsd_arm64.go src/runtime/signal_netbsd_arm64.go
+index 8dfdfeadd5..75a218cb12 100644
+--- src/runtime/signal_netbsd_arm64.go
++++ src/runtime/signal_netbsd_arm64.go
+@@ -71,3 +71,5 @@ func (c *sigctxt) set_sigcode(x uint64) { c.info._code = int32(x) }
+ func (c *sigctxt) set_sigaddr(x uint64) {
+ 	c.info._reason = uintptr(x)
+ }
++
++func (c *sigctxt) prepare_mcontext() {}
+diff --git src/runtime/signal_openbsd_arm64.go src/runtime/signal_openbsd_arm64.go
+index 3747b4f91b..8746f93d09 100644
+--- src/runtime/signal_openbsd_arm64.go
++++ src/runtime/signal_openbsd_arm64.go
+@@ -73,3 +73,5 @@ func (c *sigctxt) set_sigcode(x uint64) { c.info.si_code = int32(x) }
+ func (c *sigctxt) set_sigaddr(x uint64) {
+ 	*(*uint64)(add(unsafe.Pointer(c.info), 16)) = x
+ }
++
++func (c *sigctxt) prepare_mcontext() {}

--- a/lang/go121/files/patch-src_cmd_go_internal_modload_vendor.go
+++ b/lang/go121/files/patch-src_cmd_go_internal_modload_vendor.go
@@ -1,0 +1,11 @@
+--- src/cmd/go/internal/modload/vendor.go.orig	2023-08-02 13:51:49 UTC
++++ src/cmd/go/internal/modload/vendor.go
+@@ -144,7 +144,7 @@ func checkVendorConsistency(index *modFileIndex, modFi
+ 	readVendorList(MainModules.mustGetSingleMainModule())
+ 
+ 	pre114 := false
+-	if gover.Compare(index.goVersion, "1.14") < 0 {
++	if gover.Compare(index.goVersion, "1.14") < 0 || os.Getenv("GO_NO_VENDOR_CHECKS") == "1" {
+ 		// Go versions before 1.14 did not include enough information in
+ 		// vendor/modules.txt to check for consistency.
+ 		// If we know that we're on an earlier version, relax the consistency check.


### PR DESCRIPTION
* Cherry-pick go121 from upstream
* Apply the same patches as in #156
* Bump the default go version to 1.21 (matching upstream)