### PR TITLE
[cheriabi] Initial patch for accessibility/at-spi2-core

### DIFF
--- a/accessibility/at-spi2-core/Makefile
+++ b/accessibility/at-spi2-core/Makefile
@@ -30,6 +30,12 @@ X11_USES=		xorg
 X11_USE=		XORG=x11,xi,xtst
 X11_MESON_ENABLED=	x11
 
+.include <bsd.port.options.mk>
+
+.if ${ABI:Mpurecap}
+introspection_MESON_ARG=          disabled
+.endif
+
 post-install:
 	${RM} -r ${STAGEDIR}${PREFIX}/lib/systemd
 

--- a/accessibility/at-spi2-core/files/cheribsd.patch
+++ b/accessibility/at-spi2-core/files/cheribsd.patch
@@ -1,0 +1,59 @@
+diff --git atk/atk-enum-types.c.template atk/atk-enum-types.c.template
+index dc2cae9f..cbf4bdab 100644
+--- atk/atk-enum-types.c.template
++++ atk/atk-enum-types.c.template
+@@ -15,9 +15,9 @@
+ GType
+ @enum_name@_get_type (void)
+ {
+-  static gsize g_define_type_id__volatile;
++  static GType g_define_type_id__volatile;
+ 
+-  if (g_once_init_enter (&g_define_type_id__volatile))
++  if (g_once_init_enter_pointer (&g_define_type_id__volatile))
+     {
+       static const G@Type@Value values[] = {
+ /*** END value-header ***/
+@@ -31,7 +31,7 @@ GType
+       };
+       GType g_define_type_id =
+         g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
+-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
++      g_once_init_leave_pointer (&g_define_type_id__volatile, g_define_type_id);
+     }
+   return g_define_type_id__volatile;
+ }
+diff --git atk/atkutil.h atk/atkutil.h
+index 844fe2a1..04704408 100644
+--- atk/atkutil.h
++++ atk/atkutil.h
+@@ -329,8 +329,8 @@ const gchar *atk_get_version (void);
+   GType                                                                                    \
+       type_name##_get_type (void)                                                          \
+   {                                                                                        \
+-    static volatile gsize g_define_type_id__volatile = 0;                                  \
+-    if (g_once_init_enter (&g_define_type_id__volatile))                                   \
++    static volatile GType g_define_type_id__volatile = 0;                                  \
++    if (g_once_init_enter_pointer (&g_define_type_id__volatile))                           \
+       {                                                                                    \
+         AtkObjectFactory *factory;                                                         \
+         GType derived_type;                                                                \
+@@ -354,12 +354,12 @@ const gchar *atk_get_version (void);
+                                            (GInstanceInitFunc) type_name##_init,           \
+                                            (GTypeFlags) flags);                            \
+         { /* custom code follows */
+-#define _ATK_DEFINE_TYPE_EXTENDED_END()                              \
+-  /* following custom code */                                        \
+-  }                                                                  \
+-  g_once_init_leave (&g_define_type_id__volatile, g_define_type_id); \
+-  }                                                                  \
+-  return g_define_type_id__volatile;                                 \
++#define _ATK_DEFINE_TYPE_EXTENDED_END()                                      \
++  /* following custom code */                                                \
++  }                                                                          \
++  g_once_init_leave_pointer (&g_define_type_id__volatile, g_define_type_id); \
++  }                                                                          \
++  return g_define_type_id__volatile;                                         \
+   } /* closes type_name##_get_type() */
+ 
+ G_END_DECLS

--- a/accessibility/at-spi2-core/pkg-plist
+++ b/accessibility/at-spi2-core/pkg-plist
@@ -67,8 +67,8 @@ include/atk-1.0/atk/atkutil.h
 include/atk-1.0/atk/atkvalue.h
 include/atk-1.0/atk/atkversion.h
 include/atk-1.0/atk/atkwindow.h
-lib/girepository-1.0/Atk-1.0.typelib
-%%NO_ATKONLY%%lib/girepository-1.0/Atspi-2.0.typelib
+%%GIR%%lib/girepository-1.0/Atk-1.0.typelib
+%%GIR%%%%NO_ATKONLY%%lib/girepository-1.0/Atspi-2.0.typelib
 %%NO_ATKONLY%%lib/gnome-settings-daemon-3.0/gtk-modules/at-spi2-atk.desktop
 %%NO_ATKONLY%%lib/gtk-2.0/modules/libatk-bridge.so
 lib/libatk-1.0.so
@@ -88,8 +88,8 @@ libdata/pkgconfig/atk.pc
 %%NO_ATKONLY%%share/dbus-1/accessibility-services/org.a11y.atspi.Registry.service
 %%NO_ATKONLY%%share/dbus-1/services/org.a11y.Bus.service
 %%NO_ATKONLY%%share/defaults/at-spi2/accessibility.conf
-share/gir-1.0/Atk-1.0.gir
-%%NO_ATKONLY%%share/gir-1.0/Atspi-2.0.gir
+%%GIR%%share/gir-1.0/Atk-1.0.gir
+%%GIR%%%%NO_ATKONLY%%share/gir-1.0/Atspi-2.0.gir
 share/locale/ab/LC_MESSAGES/at-spi2-core.mo
 share/locale/af/LC_MESSAGES/at-spi2-core.mo
 share/locale/am/LC_MESSAGES/at-spi2-core.mo


### PR DESCRIPTION
Initial set of patches for accessibility/at-spi2-core generated from [1].

[1] https://github.com/CTSRD-CHERI/at-spi2-core/tree/fd01d564b5aa69d179f57546f6e4cc5f2ba414fa

Temporarily disable gobject introspection for purecap, until purecap libffi contains the support for closures required by this feature.