### PR TITLE
security/boringssl: initial patch for CheriABI

### DIFF
--- a/Mk/Uses/go.mk
+++ b/Mk/Uses/go.mk
@@ -106,8 +106,8 @@ GO_TESTFLAGS+=	-buildvcs=false
 .  endif
 
 CGO_ENABLED?=	1
-CGO_CFLAGS+=	-I${LOCALBASE}/include
-CGO_LDFLAGS+=	-L${LOCALBASE}/lib
+CGO_CFLAGS+=	-I${GO_LOCALBASE}/include
+CGO_LDFLAGS+=	-L${GO_LOCALBASE}/lib
 
 .  if ${ARCH} == armv6 || ${ARCH} == armv7
 GOARM?=		${ARCH:C/armv//}
@@ -118,7 +118,12 @@ GO_GOSUMDB?=	sum.golang.org
 
 # Read-only variables
 
-GO_CMD=		${LOCALBASE}/bin/go${GO_SUFFIX}
+.  if ${USE_GO:Mpkg64}
+GO_LOCALBASE=	${LOCALBASE64}
+.  else
+GO_LOCALBASE=	${LOCALBASE}
+.  endif
+GO_CMD=		${GO_LOCALBASE}/bin/go${GO_SUFFIX}
 GO_WRKDIR_BIN=	${WRKDIR}/bin
 GO_ENV+=	CGO_ENABLED=${CGO_ENABLED} \
 		CGO_CFLAGS="${CGO_CFLAGS}" \

--- a/lang/go121/Makefile
+++ b/lang/go121/Makefile
@@ -7,6 +7,9 @@ MASTER_SITES=	https://golang.org/dl/ \
 DISTFILES=	go${DISTVERSION}.src.tar.gz \
 		go-${OPSYS:tl}-${GOARCH_${ARCH}}${GOARM_${ARCH}}-${BOOTSTRAP_TAG}.tar.xz:bootstrap
 
+BROKEN_purecap=	Does not build for CheriABI
+USE_PKG64=	1
+
 # Avoid conflicting patch files
 PATCHFILES=
 

--- a/security/boringssl/Makefile
+++ b/security/boringssl/Makefile
@@ -21,6 +21,8 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 USES=		cmake:insource cpe go:no_targets localbase perl5
 
+USE_GO=		pkg64
+
 CONFLICTS_INSTALL=	libressl libressl-devel \
 			openssl openssl3[01] openssl-quictls
 
@@ -36,6 +38,12 @@ LDFLAGS+=	-Wl,-rpath,${LOCALBASE}/lib
 TEST_TARGET=	run_tests
 MAKE_ENV+=	GOFLAGS=-mod=readonly \
 		GOPROXY=file://${DISTDIR}
+
+.include <bsd.port.options.mk>
+
+.if ${ABI:Mpurecap}
+CMAKE_ARGS+=	-DOPENSSL_NO_ASM=1
+.endif
 
 do-install:
 	${INSTALL_PROGRAM} ${WRKSRC}/tool/bssl ${STAGEDIR}${PREFIX}/bin/

--- a/security/boringssl/files/cheribsd.patch
+++ b/security/boringssl/files/cheribsd.patch
@@ -1,0 +1,51 @@
+diff --git crypto/cipher_extra/internal.h crypto/cipher_extra/internal.h
+index 39ab950fe..02bb60047 100644
+--- crypto/cipher_extra/internal.h
++++ crypto/cipher_extra/internal.h
+@@ -176,7 +176,13 @@ union chacha20_poly1305_seal_data {
+ 
+ static_assert(sizeof(union chacha20_poly1305_open_data) == 48,
+               "wrong chacha20_poly1305_open_data size");
++#if defined(__CHERI_PURE_CAPABILITY__)
++// Adjust expected size of union chacha20_poly1305_seal_data for the
++// wider and stronger alignment requirements of capabilities.
++static_assert(sizeof(union chacha20_poly1305_seal_data) == 48 + 16 + 8 + 8,
++#else // defined(__CHERI_PURE_CAPABILITY__)
+ static_assert(sizeof(union chacha20_poly1305_seal_data) == 48 + 8 + 8,
++#endif // defined(__CHERI_PURE_CAPABILITY__)
+               "wrong chacha20_poly1305_seal_data size");
+ 
+ OPENSSL_INLINE int chacha20_poly1305_asm_capable(void) {
+diff --git crypto/mem.c crypto/mem.c
+index 89832fce5..519b41ea7 100644
+--- crypto/mem.c
++++ crypto/mem.c
+@@ -80,7 +80,11 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
+ #include "internal.h"
+ 
+ 
++#if defined(__CHERI_PURE_CAPABILITY__)
++#define OPENSSL_MALLOC_PREFIX sizeof(max_align_t)
++#else // defined(__CHERI_PURE_CAPABILITY__)
+ #define OPENSSL_MALLOC_PREFIX 8
++#endif //  defined(__CHERI_PURE_CAPABILITY__)
+ static_assert(OPENSSL_MALLOC_PREFIX >= sizeof(size_t), "size_t too large");
+ 
+ #if defined(OPENSSL_ASAN)
+diff --git include/openssl/aead.h include/openssl/aead.h
+index 376bff17a..39a47a27b 100644
+--- include/openssl/aead.h
++++ include/openssl/aead.h
+@@ -210,7 +210,12 @@ OPENSSL_EXPORT size_t EVP_AEAD_max_tag_len(const EVP_AEAD *aead);
+ // AEAD operations.
+ 
+ union evp_aead_ctx_st_state {
++#if defined(__CHERI_PURE_CAPABILITY__)
++  uint8_t opaque[800];
++  max_align_t max_alignment;
++#else // defined(__CHERI_PURE_CAPABILITY__)
+   uint8_t opaque[564];
++#endif // defined(__CHERI_PURE_CAPABILITY__)
+   uint64_t alignment;
+ };
+ 


### PR DESCRIPTION
Initial patch for security/boringssl generated from [1].

[1] https://github.com/CTSRD-CHERI/boringssl/tree/53f1fab27782b3941b93968916a92f9dea4936ea

Temporarily disable Go asynchronous preemption in security/boringssl when running go during build and test.

Mk/Uses/go.mk: initial patch to support as build/test dependency

1. Added GO_LOCALBASE conditional set to LOCALBASE64 when a port's USE_GO is set to pkg64 and LOCALBASE otherwise.
2. Added to GODEBUG=asyncpreemptoff=1 to disable asynchronous preemption. Note that this may also be required to be added to a port's MAKE_ENV depending on how Go is used.

