### PR TITLE
devel/jsoncpp: initial patch for CheriABI

### DIFF
--- a/devel/jsoncpp/files/cheribsd.patch
+++ b/devel/jsoncpp/files/cheribsd.patch
@@ -1,0 +1,70 @@
+diff --git include/json/allocator.h include/json/allocator.h
+index 95ef8a5..7540642 100644
+--- include/json/allocator.h
++++ include/json/allocator.h
+@@ -9,7 +9,8 @@
+ #include <cstring>
+ #include <memory>
+ 
+-#pragma pack(push, 8)
++#pragma pack(push)
++#pragma pack()
+ 
+ namespace Json {
+ template <typename T> class SecureAllocator {
+diff --git include/json/json_features.h include/json/json_features.h
+index 7c7e9f5..e4a61d6 100644
+--- include/json/json_features.h
++++ include/json/json_features.h
+@@ -10,7 +10,8 @@
+ #include "forwards.h"
+ #endif // if !defined(JSON_IS_AMALGAMATION)
+ 
+-#pragma pack(push, 8)
++#pragma pack(push)
++#pragma pack()
+ 
+ namespace Json {
+ 
+diff --git include/json/reader.h include/json/reader.h
+index be0d767..46975d8 100644
+--- include/json/reader.h
++++ include/json/reader.h
+@@ -23,7 +23,8 @@
+ #pragma warning(disable : 4251)
+ #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
+ 
+-#pragma pack(push, 8)
++#pragma pack(push)
++#pragma pack()
+ 
+ namespace Json {
+ 
+diff --git include/json/value.h include/json/value.h
+index 0edeb05..57ecb13 100644
+--- include/json/value.h
++++ include/json/value.h
+@@ -53,7 +53,8 @@
+ #pragma warning(disable : 4251 4275)
+ #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
+ 
+-#pragma pack(push, 8)
++#pragma pack(push)
++#pragma pack()
+ 
+ /** \brief JSON (JavaScript Object Notation).
+  */
+diff --git include/json/writer.h include/json/writer.h
+index 88a3b12..f26e976 100644
+--- include/json/writer.h
++++ include/json/writer.h
+@@ -20,7 +20,8 @@
+ #pragma warning(disable : 4251)
+ #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
+ 
+-#pragma pack(push, 8)
++#pragma pack(push)
++#pragma pack()
+ 
+ namespace Json {
+ 


### PR DESCRIPTION
Apply @jrtc27 's fix from master to the port tree version (1.9.5):

`git cherry-pick -x 42e892d96e47b1f6e29844cc705e148ec4856448`

Initial patch for devel/jsoncpp generated from [1].

[1] https://github.com/CTSRD-CHERI/jsoncpp/tree/5cc9ec8217716e6a129ca93bedc441d7079f4407