### PR TITLE
devel/libinotify: Stop marking as broken for purecap

### DIFF
--- a/devel/libinotify/Makefile.purecap
+++ b/devel/libinotify/Makefile.purecap
@@ -1,1 +1,0 @@
-BROKEN_purecap_failed=1


### PR DESCRIPTION
This was fixed but the marker was never removed so we skip trying to
build it under qemu-user with the sample poudriere config (on real
hardware it still gets built, so there's no indication of anything being
wrong).

Fixes:	15d9ba6c0c82 ("devel/libinotify: Fix building on CHERI")
