### PR TITLE
www/nginx: Use ETCDIR substitution for path to config file

### DIFF
--- a/www/nginx/files/nginx.in
+++ b/www/nginx/files/nginx.in
@@ -44,7 +44,7 @@ command="%%PREFIX%%/sbin/nginx"
 _pidprefix="%%NGINX_RUNDIR%%"
 pidfile="${_pidprefix}/${name}.pid"
 _tmpprefix="%%NGINX_TMPDIR%%"
-required_files=%%PREFIX%%/etc/nginx/nginx.conf
+required_files=%%ETCDIR%%/nginx.conf
 extra_commands="reload configtest upgrade gracefulstop"
 
 [ -z "$nginx_enable" ]		&& nginx_enable="NO"


### PR DESCRIPTION
This fixes slave ports.